### PR TITLE
Get rid of BW cheese

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_GT_MaterialReference.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_GT_MaterialReference.java
@@ -140,7 +140,7 @@ public class BW_GT_MaterialReference {
 
     public static Werkstoff Wood = new Werkstoff(Materials.Wood, ADD_CASINGS_ONLY, BIOLOGICAL,31_766+809);
    // public static Werkstoff WoodSealed = new Werkstoff(Materials.WoodSealed, ADD_CASINGS_ONLY, BIOLOGICAL,31_766+889);
-    public static Werkstoff Cheese = new Werkstoff(Materials.Cheese, new Werkstoff.GenerationFeatures().addCasings().addMetalItems().addMultipleIngotMetalWorkingItems().enforceUnification(), BIOLOGICAL,31_766+894);
+    //public static Werkstoff Cheese = new Werkstoff(Materials.Cheese, new Werkstoff.GenerationFeatures().addCasings().addMetalItems().addMultipleIngotMetalWorkingItems().enforceUnification(), BIOLOGICAL,31_766+894);
 
     public static Werkstoff Steel = new Werkstoff(Materials.Steel, ADD_CASINGS_ONLY, COMPOUND,31_766+305);
     public static Werkstoff Polytetrafluoroethylene = new Werkstoff(Materials.Polytetrafluoroethylene, ADD_CASINGS_ONLY, COMPOUND,31_766+473);


### PR DESCRIPTION
Apparently it was added for testing, so it's unneeded, as there's already a GT cheese, and it messes up GC cheese ore for space plant. I left it commented out in case someone wants to use it for testing something again.

PS: I don't think anything uses those casings in the same file either.

```
Prometheus0000 — Yesterday at 4:32 PM
@👏🏻ＢΛ - ЯＴ👏🏻|борода|bartworks Is there any particular reason you added a BW cheese? It's messing the GC cheese, 
and I see no reason for it to exist in the first place, since there was already a GT cheese
👏🏻ＢΛ - ЯＴ👏🏻|борода|bartworks — Yesterday at 7:42 PM
it was a test
also, GC is at fault here, since it doesnt support OreDict, not like GT, which does support it
Prometheus0000 — Yesterday at 7:55 PM
Both GT and GC cheese ore get forcibly unified to BW ore, so I'm not sure what oredict has to do with it
👏🏻ＢΛ - ЯＴ👏🏻|борода|bartworks — Yesterday at 8:31 PM
GT can process anything tagged: "oreCheese"
GC can't.
```

