### PR TITLE
Fix void miner ore generation

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -22,6 +22,8 @@
 
 package com.github.bartimaeusnek.crossmod.galacticgreg;
 
+//import com.github.bartimaeusnek.bartworks.MainMod;
+
 import bloodasp.galacticgreg.GT_Worldgen_GT_Ore_Layer_Space;
 import bloodasp.galacticgreg.GT_Worldgen_GT_Ore_SmallPieces_Space;
 import bloodasp.galacticgreg.GalacticGreg;
@@ -268,12 +270,19 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
     }
 
     private Pair<Integer,Boolean> getOreDamage() {
-        int curentWeight = 0;
+		/*
+		dropmap.values().forEach(f -> {
+			if(f < 1.f)
+				MainMod.LOGGER.info(f);
+		});
+		*/
+		
+        float curentWeight = 0.f;
         while (true) {
-            int randomeint = (Math.abs(XSTR.XSTR_INSTANCE.nextInt((int) Math.ceil(totalWeight))));
+            float randomnumber = XSTR.XSTR_INSTANCE.nextFloat() * totalWeight;
             for (Map.Entry<Pair<Integer,Boolean>, Float> entry : dropmap.entrySet()) {
                 curentWeight += entry.getValue();
-                if (randomeint < curentWeight)
+                if (randomnumber < curentWeight)
                     return entry.getKey();
             }
         }

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -22,8 +22,6 @@
 
 package com.github.bartimaeusnek.crossmod.galacticgreg;
 
-//import com.github.bartimaeusnek.bartworks.MainMod;
-
 import bloodasp.galacticgreg.GT_Worldgen_GT_Ore_Layer_Space;
 import bloodasp.galacticgreg.GT_Worldgen_GT_Ore_SmallPieces_Space;
 import bloodasp.galacticgreg.GalacticGreg;
@@ -270,13 +268,6 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
     }
 
     private Pair<Integer,Boolean> getOreDamage() {
-		/*
-		dropmap.values().forEach(f -> {
-			if(f < 1.f)
-				MainMod.LOGGER.info(f);
-		});
-		*/
-		
         float curentWeight = 0.f;
         while (true) {
             float randomnumber = XSTR.XSTR_INSTANCE.nextFloat() * totalWeight;

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -140,7 +140,7 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
     @Override
     protected boolean workingAtBottom(ItemStack aStack, int xDrill, int yDrill, int zDrill, int xPipe, int zPipe, int yHead, int oldYHead) {
         makeDropMap();
-        if(dropmap.size() > 0){
+        if(totalWeight != 0.f){
             handleFluidConsumption();
             handleOutputs();
             return true;

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -140,9 +140,15 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
     @Override
     protected boolean workingAtBottom(ItemStack aStack, int xDrill, int yDrill, int zDrill, int xPipe, int zPipe, int yHead, int oldYHead) {
         makeDropMap();
-        handleFluidConsumption();
-        handleOutputs();
-        return true;
+        if(dropmap.size() > 0){
+            handleFluidConsumption();
+            handleOutputs();
+            return true;
+        }
+        else{
+            stopMachine();
+            return false;
+        }
     }
 
     @Override
@@ -215,7 +221,7 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
         }
     }
 
-    private void put(Pair<Integer,Boolean> key, float value){
+    private void addDrop(Pair<Integer,Boolean> key, float value){
         if(!dropmap.containsKey(key))
             dropmap.put(key, value);
         else
@@ -224,17 +230,17 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
 
     private void getDropsVanillaVeins(Predicate<GT_Worldgen_GT_Ore_Layer> oreLayerPredicate) {
         GT_Worldgen_GT_Ore_Layer.sList.stream().filter(gt_worldgen -> gt_worldgen.mEnabled && oreLayerPredicate.test(gt_worldgen)).forEach(element -> {
-                    put(new Pair<>((int) element.mPrimaryMeta,false), (float) element.mWeight);
-                    put(new Pair<>((int) element.mSecondaryMeta,false), (float) element.mWeight);
-                    put(new Pair<>((int) element.mSporadicMeta,false), (element.mWeight / 8f));
-                    put(new Pair<>((int) element.mBetweenMeta,false), (element.mWeight / 8f));
+                    addDrop(new Pair<>((int) element.mPrimaryMeta,false), (float) element.mWeight);
+                    addDrop(new Pair<>((int) element.mSecondaryMeta,false), (float) element.mWeight);
+                    addDrop(new Pair<>((int) element.mSporadicMeta,false), (element.mWeight / 8f));
+                    addDrop(new Pair<>((int) element.mBetweenMeta,false), (element.mWeight / 8f));
                 }
         );
     }
 
     private void getDropsVanillaSmallOres(Predicate<GT_Worldgen_GT_Ore_SmallPieces> smallOresPredicate) {
         GT_Worldgen_GT_Ore_SmallPieces.sList.stream().filter(gt_worldgen -> gt_worldgen.mEnabled && smallOresPredicate.test(gt_worldgen)).forEach(element ->
-                put(new Pair<>((int) element.mMeta,false), (float) element.mAmount)
+                addDrop(new Pair<>((int) element.mMeta,false), (float) element.mAmount)
         );
     }
 
@@ -255,10 +261,10 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
 
         space.forEach(
                 element -> {
-                    put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mPrimaryMeta,false), (float) ((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight);
-                    put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mSecondaryMeta,false), (float) ((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight);
-                    put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mSporadicMeta,false), (((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight / 8f));
-                    put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mBetweenMeta,false), (((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight / 8f));
+                    addDrop(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mPrimaryMeta,false), (float) ((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight);
+                    addDrop(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mSecondaryMeta,false), (float) ((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight);
+                    addDrop(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mSporadicMeta,false), (((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight / 8f));
+                    addDrop(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mBetweenMeta,false), (((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight / 8f));
                 }
         );
     }
@@ -270,7 +276,7 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
 
         space.forEach(
                 element ->
-                        put(new Pair<>((int) ((GT_Worldgen_GT_Ore_SmallPieces_Space) element).mMeta,false), (float) ((GT_Worldgen_GT_Ore_SmallPieces_Space) element).mAmount)
+                        addDrop(new Pair<>((int) ((GT_Worldgen_GT_Ore_SmallPieces_Space) element).mMeta,false), (float) ((GT_Worldgen_GT_Ore_SmallPieces_Space) element).mAmount)
         );
     }
 
@@ -335,9 +341,9 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
             List<Pair<Integer,Boolean>> data = element.getStacksRawData();
             for (int i = 0; i < data.size(); i++) {
                 if (i < data.size()-2)
-                    put(data.get(i), (float) element.mWeight);
+                    addDrop(data.get(i), (float) element.mWeight);
                 else
-                    put(data.get(i), (element.mWeight/8f));
+                    addDrop(data.get(i), (element.mWeight/8f));
             }
         };
     }
@@ -368,13 +374,13 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
 
             space.forEach(
                     element ->
-                            put(new Pair<>(((BW_Worldgen_Ore_SmallOre_Space) element).mPrimaryMeta, ((BW_Worldgen_Ore_SmallOre_Space) element).bwOres != 0), (float) ((BW_Worldgen_Ore_SmallOre_Space) element).mDensity)
+                            addDrop(new Pair<>(((BW_Worldgen_Ore_SmallOre_Space) element).mPrimaryMeta, ((BW_Worldgen_Ore_SmallOre_Space) element).bwOres != 0), (float) ((BW_Worldgen_Ore_SmallOre_Space) element).mDensity)
             );
         } catch (NullPointerException ignored) {}
     }
 
     private void handleExtraDrops(int id) {
-        Optional.ofNullable(getExtraDropsDimMap().get(id)).ifPresent(e -> e.forEach(f -> put(f.getKey(), f.getValue())));
+        Optional.ofNullable(getExtraDropsDimMap().get(id)).ifPresent(e -> e.forEach(f -> addDrop(f.getKey(), f.getValue())));
     }
 
     private void calculateTotalWeight() {

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -215,19 +215,26 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
         }
     }
 
+    private void put(Pair<Integer,Boolean> key, float value){
+        if(!dropmap.containsKey(key))
+            dropmap.put(key, value);
+        else
+            dropmap.put(key, dropmap.get(key) + value);
+    }
+
     private void getDropsVanillaVeins(Predicate<GT_Worldgen_GT_Ore_Layer> oreLayerPredicate) {
         GT_Worldgen_GT_Ore_Layer.sList.stream().filter(gt_worldgen -> gt_worldgen.mEnabled && oreLayerPredicate.test(gt_worldgen)).forEach(element -> {
-                    dropmap.put(new Pair<>((int) element.mPrimaryMeta,false), (float) element.mWeight);
-                    dropmap.put(new Pair<>((int) element.mSecondaryMeta,false), (float) element.mWeight);
-                    dropmap.put(new Pair<>((int) element.mSporadicMeta,false), (element.mWeight / 8f));
-                    dropmap.put(new Pair<>((int) element.mBetweenMeta,false), (element.mWeight / 8f));
+                    put(new Pair<>((int) element.mPrimaryMeta,false), (float) element.mWeight);
+                    put(new Pair<>((int) element.mSecondaryMeta,false), (float) element.mWeight);
+                    put(new Pair<>((int) element.mSporadicMeta,false), (element.mWeight / 8f));
+                    put(new Pair<>((int) element.mBetweenMeta,false), (element.mWeight / 8f));
                 }
         );
     }
 
     private void getDropsVanillaSmallOres(Predicate<GT_Worldgen_GT_Ore_SmallPieces> smallOresPredicate) {
         GT_Worldgen_GT_Ore_SmallPieces.sList.stream().filter(gt_worldgen -> gt_worldgen.mEnabled && smallOresPredicate.test(gt_worldgen)).forEach(element ->
-                dropmap.put(new Pair<>((int) element.mMeta,false), (float) element.mAmount)
+                put(new Pair<>((int) element.mMeta,false), (float) element.mAmount)
         );
     }
 
@@ -248,10 +255,10 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
 
         space.forEach(
                 element -> {
-                    dropmap.put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mPrimaryMeta,false), (float) ((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight);
-                    dropmap.put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mSecondaryMeta,false), (float) ((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight);
-                    dropmap.put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mSporadicMeta,false), (((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight / 8f));
-                    dropmap.put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mBetweenMeta,false), (((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight / 8f));
+                    put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mPrimaryMeta,false), (float) ((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight);
+                    put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mSecondaryMeta,false), (float) ((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight);
+                    put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mSporadicMeta,false), (((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight / 8f));
+                    put(new Pair<>((int) ((GT_Worldgen_GT_Ore_Layer_Space) element).mBetweenMeta,false), (((GT_Worldgen_GT_Ore_Layer_Space) element).mWeight / 8f));
                 }
         );
     }
@@ -263,7 +270,7 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
 
         space.forEach(
                 element ->
-                        dropmap.put(new Pair<>((int) ((GT_Worldgen_GT_Ore_SmallPieces_Space) element).mMeta,false), (float) ((GT_Worldgen_GT_Ore_SmallPieces_Space) element).mAmount)
+                        put(new Pair<>((int) ((GT_Worldgen_GT_Ore_SmallPieces_Space) element).mMeta,false), (float) ((GT_Worldgen_GT_Ore_SmallPieces_Space) element).mAmount)
         );
     }
 
@@ -311,10 +318,10 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
 
     private void getDropMapRoss(int aID) {
         Consumer<BW_OreLayer> addToList = makeAddToList();
-        if (aID == ConfigHandler.ross128BID)
-            BW_WorldGenRoss128b.sList.forEach(addToList);
-        else if (aID == ConfigHandler.ross128BAID)
-            BW_WorldGenRoss128ba.sList.forEach(addToList);
+        BW_OreLayer.sList.stream()
+                .filter(gt_worldgen -> gt_worldgen.mEnabled && gt_worldgen instanceof BW_OreLayer && gt_worldgen.isGenerationAllowed(null, aID, 0))
+                .collect(Collectors.toSet())
+                .forEach(addToList);
     }
 
     private void getDropMapBartworks(ModDimensionDef finalDef) {
@@ -327,10 +334,10 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
         return element -> {
             List<Pair<Integer,Boolean>> data = element.getStacksRawData();
             for (int i = 0; i < data.size(); i++) {
-                if (i < data.size()-1)
-                    dropmap.put(data.get(i), (float) element.mWeight);
+                if (i < data.size()-2)
+                    put(data.get(i), (float) element.mWeight);
                 else
-                    dropmap.put(data.get(i), (element.mWeight/8f));
+                    put(data.get(i), (element.mWeight/8f));
             }
         };
     }
@@ -361,13 +368,13 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
 
             space.forEach(
                     element ->
-                            dropmap.put(new Pair<>(((BW_Worldgen_Ore_SmallOre_Space) element).mPrimaryMeta, ((BW_Worldgen_Ore_SmallOre_Space) element).bwOres != 0), (float) ((BW_Worldgen_Ore_SmallOre_Space) element).mDensity)
+                            put(new Pair<>(((BW_Worldgen_Ore_SmallOre_Space) element).mPrimaryMeta, ((BW_Worldgen_Ore_SmallOre_Space) element).bwOres != 0), (float) ((BW_Worldgen_Ore_SmallOre_Space) element).mDensity)
             );
         } catch (NullPointerException ignored) {}
     }
 
     private void handleExtraDrops(int id) {
-        Optional.ofNullable(getExtraDropsDimMap().get(id)).ifPresent(e -> e.forEach(f -> dropmap.put(f.getKey(), f.getValue())));
+        Optional.ofNullable(getExtraDropsDimMap().get(id)).ifPresent(e -> e.forEach(f -> put(f.getKey(), f.getValue())));
     }
 
     private void calculateTotalWeight() {


### PR DESCRIPTION
Sporadic ores from oreveins with weight less than 8 have weight less than 1 and the code is written in a way that makes those ores unable to generate. This code fixes this without changing generation chances.