### PR TITLE
Add number formatting and fix array OOB

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/client/gui/GT_GUIContainer_LESU.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/client/gui/GT_GUIContainer_LESU.java
@@ -30,6 +30,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.gui.GT_GUIContainer;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
@@ -56,11 +57,11 @@ public class GT_GUIContainer_LESU extends GT_GUIContainer {
         this.drawString(this.fontRendererObj, "L.E.S.U.", 11, 8, 16448255);
         if (this.mContainer != null) {
             String percell = String.valueOf(ConfigHandler.energyPerCell).substring(1);
-            this.drawString(this.fontRendererObj, "EU: " + this.mContainer.mEnergy, 11, 16, 16448255);
-            this.drawString(this.fontRendererObj, "MAX: " + (this.c.getBaseMetaTileEntity().isActive() ? this.mContainer.mOutput + percell : Integer.toString(0)), 11, 24, 16448255);
-            this.drawString(this.fontRendererObj, "MAX EU/t IN: " + this.mContainer.mInput, 11, 32, 16448255);
-            this.drawString(this.fontRendererObj, "EU/t OUT: " + this.mContainer.mOutput, 11, 40, 16448255);
-            this.drawString(this.fontRendererObj, "AMP/t IN/OUT: " + this.c.getBaseMetaTileEntity().getInputAmperage(), 11, 48, 16448255);
+            this.drawString(this.fontRendererObj, "EU: " + GT_Utility.formatNumbers(this.mContainer.mEnergy), 11, 16, 16448255);
+            this.drawString(this.fontRendererObj, "MAX: " + (this.c.getBaseMetaTileEntity().isActive() ? GT_Utility.formatNumbers(this.mContainer.mOutput) + percell : Integer.toString(0)), 11, 24, 16448255);
+            this.drawString(this.fontRendererObj, "MAX EU/t IN: " + GT_Utility.formatNumbers(this.mContainer.mInput), 11, 32, 16448255);
+            this.drawString(this.fontRendererObj, "EU/t OUT: " + GT_Utility.formatNumbers(this.mContainer.mOutput), 11, 40, 16448255);
+            this.drawString(this.fontRendererObj, "AMP/t IN/OUT: " + GT_Utility.formatNumbers(this.c.getBaseMetaTileEntity().getInputAmperage()), 11, 48, 16448255);
             if (this.c.maxEUStore() >= Long.MAX_VALUE - 1) {
                 this.drawString(this.fontRendererObj, StatCollector.translateToLocal("tooltip.LESU.0.name"), 11, 56, Color.YELLOW.getRGB());
             }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/classic/BW_TileEntity_HeatedWaterPump.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/classic/BW_TileEntity_HeatedWaterPump.java
@@ -28,6 +28,7 @@ import com.github.bartimaeusnek.bartworks.API.ITileHasDifferentTextureSides;
 import com.github.bartimaeusnek.bartworks.API.ITileWithGUI;
 import com.github.bartimaeusnek.bartworks.MainMod;
 import com.github.bartimaeusnek.bartworks.common.configs.ConfigHandler;
+import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Pollution;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -328,7 +329,10 @@ public class BW_TileEntity_HeatedWaterPump extends TileEntity implements ITileDr
 
     @Override
     public String[] getInfoData() {
-        return new String[]{StatCollector.translateToLocal("tooltip.tile.waterpump.0.name") + " " + ConfigHandler.mbWaterperSec + StatCollector.translateToLocal("tooltip.tile.waterpump.1.name"), StatCollector.translateToLocal("tooltip.tile.waterpump.2.name")};
+        return new String[]{
+                StatCollector.translateToLocal("tooltip.tile.waterpump.0.name") + " " +
+                        GT_Utility.formatNumbers(ConfigHandler.mbWaterperSec) + StatCollector.translateToLocal("tooltip.tile.waterpump.1.name"),
+                StatCollector.translateToLocal("tooltip.tile.waterpump.2.name")};
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_LESU.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_LESU.java
@@ -160,7 +160,7 @@ public class GT_TileEntity_LESU extends GT_MetaTileEntity_MultiBlockBase {
         ArrayList<String> e = new ArrayList<>();
         String[] dsc = StatCollector.translateToLocal("tooltip.tile.lesu.0.name").split(";");
         Collections.addAll(e, dsc);
-        e.add(StatCollector.translateToLocal("tooltip.tile.lesu.1.name") + " " + ConfigHandler.energyPerCell + "EU");
+        e.add(StatCollector.translateToLocal("tooltip.tile.lesu.1.name") + " " + GT_Utility.formatNumbers(ConfigHandler.energyPerCell) + "EU");
         dsc = StatCollector.translateToLocal("tooltip.tile.lesu.2.name").split(";");
         Collections.addAll(e, dsc);
         e.add(ChatColorHelper.RED + StatCollector.translateToLocal("tooltip.tile.lesu.3.name"));

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_THTR.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_THTR.java
@@ -307,11 +307,11 @@ public class GT_TileEntity_THTR extends GT_MetaTileEntity_MultiBlockBase {
     @Override
     public String[] getInfoData() {
         return new String[]{
-                "Progress:", this.mProgresstime / 20 + "secs", this.mMaxProgresstime / 20 + "secs",
-                "BISO-Pebbles:", this.BISOPeletSupply + "pcs.",
-                "TRISO-Pebbles:", this.TRISOPeletSupply + "pcs.",
-                "Helium-Level:", this.HeliumSupply+"L / "+ GT_TileEntity_THTR.HELIUM_NEEDED +"L",
-                "Coolant/t:", this.savedBISO+this.savedTRISO >= 100000 ? (long) ((0.00711111111111111111111111111111D * (double) this.savedTRISO + 0.00474074074074074074074074074074D * (double) this.savedBISO))+"L/t" : "0L/t",
+                "Progress:", GT_Utility.formatNumbers(this.mProgresstime / 20) + "secs", GT_Utility.formatNumbers(this.mMaxProgresstime / 20) + "secs",
+                "BISO-Pebbles:", GT_Utility.formatNumbers(this.BISOPeletSupply) + "pcs.",
+                "TRISO-Pebbles:", GT_Utility.formatNumbers(this.TRISOPeletSupply) + "pcs.",
+                "Helium-Level:", GT_Utility.formatNumbers(this.HeliumSupply) + "L / " + GT_Utility.formatNumbers(GT_TileEntity_THTR.HELIUM_NEEDED) + "L",
+                "Coolant/t:", GT_Utility.formatNumbers(this.savedBISO+this.savedTRISO >= 100000 ? (long) ((0.00711111111111111111111111111111D * (double) this.savedTRISO + 0.00474074074074074074074074074074D * (double) this.savedBISO)) : 0) + "L/t",
                 "Problems:", String.valueOf(this.getIdealStatus() - this.getRepairStatus())
         };
     }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -311,7 +311,25 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
             }
         }
 
-        return new String[]{StatCollector.translateToLocal("GT5U.multiblock.Progress") + ": " + EnumChatFormatting.GREEN + this.mProgresstime / 20 + EnumChatFormatting.RESET + " s / " + EnumChatFormatting.YELLOW + this.mMaxProgresstime / 20 + EnumChatFormatting.RESET + " s", StatCollector.translateToLocal("GT5U.multiblock.energy") + ": " + EnumChatFormatting.GREEN + storedEnergy + EnumChatFormatting.RESET + " EU / " + EnumChatFormatting.YELLOW + maxEnergy + EnumChatFormatting.RESET + " EU", StatCollector.translateToLocal("GT5U.multiblock.usage") + ": " + EnumChatFormatting.RED + -this.lEUt + EnumChatFormatting.RESET + " EU/t", StatCollector.translateToLocal("GT5U.multiblock.mei") + ": " + EnumChatFormatting.YELLOW + this.getMaxInputVoltage() + EnumChatFormatting.RESET + " EU/t(*2A) " + StatCollector.translateToLocal("GT5U.machines.tier") + ": " + EnumChatFormatting.YELLOW + GT_Values.VN[GT_Utility.getTier(this.getMaxInputVoltage())] + EnumChatFormatting.RESET, StatCollector.translateToLocal("GT5U.multiblock.problems") + ": " + EnumChatFormatting.RED + (this.getIdealStatus() - this.getRepairStatus()) + EnumChatFormatting.RESET + " " + StatCollector.translateToLocal("GT5U.multiblock.efficiency") + ": " + EnumChatFormatting.YELLOW + (float) this.mEfficiency / 100.0F + EnumChatFormatting.RESET + " %", StatCollector.translateToLocal("GT5U.multiblock.pollution") + ": " + EnumChatFormatting.GREEN + mPollutionReduction + EnumChatFormatting.RESET + " %"};
+        return new String[]{
+                StatCollector.translateToLocal("GT5U.multiblock.Progress") + ": " +
+                        EnumChatFormatting.GREEN + GT_Utility.formatNumbers(this.mProgresstime / 20) + EnumChatFormatting.RESET + " s / " +
+                        EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(this.mMaxProgresstime / 20) + EnumChatFormatting.RESET + " s",
+                StatCollector.translateToLocal("GT5U.multiblock.energy") + ": " +
+                        EnumChatFormatting.GREEN + GT_Utility.formatNumbers(storedEnergy) + EnumChatFormatting.RESET + " EU / " +
+                        EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(maxEnergy) + EnumChatFormatting.RESET + " EU",
+                StatCollector.translateToLocal("GT5U.multiblock.usage") + ": " +
+                        EnumChatFormatting.RED + GT_Utility.formatNumbers(-this.lEUt) + EnumChatFormatting.RESET + " EU/t",
+                StatCollector.translateToLocal("GT5U.multiblock.mei") + ": " +
+                        EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(this.getMaxInputVoltage()) + EnumChatFormatting.RESET + " EU/t(*2A) " +
+                        StatCollector.translateToLocal("GT5U.machines.tier") + ": " +
+                        EnumChatFormatting.YELLOW + GT_Values.VN[GT_Utility.getTier(this.getMaxInputVoltage())] + EnumChatFormatting.RESET,
+                StatCollector.translateToLocal("GT5U.multiblock.problems") + ": " +
+                        EnumChatFormatting.RED + (this.getIdealStatus() - this.getRepairStatus()) + EnumChatFormatting.RESET + " " +
+                        StatCollector.translateToLocal("GT5U.multiblock.efficiency") + ": " +
+                        EnumChatFormatting.YELLOW + (float) this.mEfficiency / 100.0F + EnumChatFormatting.RESET + " %",
+                StatCollector.translateToLocal("GT5U.multiblock.pollution") + ": " +
+                        EnumChatFormatting.GREEN + mPollutionReduction + EnumChatFormatting.RESET + " %"};
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -346,7 +346,7 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
         FluidStack[] tFluids = this.getStoredFluids().toArray(new FluidStack[0]);
         long nominalV = LoaderReference.tectech ? TecTechUtils.getnominalVoltageTT(this) : BW_Util.getnominalVoltage(this);
 
-        byte tTier = (byte) Math.max(1, GT_Utility.getTier(nominalV));
+        byte tTier = (byte) Math.max(1, Math.min(GT_Utility.getTier(nominalV), V.length - 1));
         GT_Recipe tRecipe;
         if (circuitMode > 0 && Arrays.stream(tInputs).anyMatch(e -> GT_Utility.areStacksEqual(e, GT_Utility.getIntegratedCircuit(circuitMode), true))) {
             List<ItemStack> modInputs = Arrays.stream(tInputs).filter(Objects::nonNull).filter(e -> !e.getItem().equals(GT_Utility.getIntegratedCircuit(circuitMode).getItem())).collect(Collectors.toList());

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
+import static gregtech.api.enums.GT_Values.V;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
 public class GT_TileEntity_MegaDistillTower extends GT_MetaTileEntity_DistillationTower {
@@ -219,7 +220,7 @@ public class GT_TileEntity_MegaDistillTower extends GT_MetaTileEntity_Distillati
         }
 
         long tVoltage = this.getMaxInputVoltage();
-        byte tTier = (byte) Math.max(0, GT_Utility.getTier(tVoltage));
+        byte tTier = (byte) Math.max(0, Math.min(GT_Utility.getTier(tVoltage), V.length - 1));
 
         long nominalV = BW_Util.getnominalVoltage(this);
         FluidStack[] tFluids = tFluidList.toArray(new FluidStack[0]);

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
@@ -99,7 +99,7 @@ public class GT_TileEntity_MegaVacuumFreezer extends GT_MetaTileEntity_VacuumFre
 
         long nominalV = LoaderReference.tectech ? TecTechUtils.getnominalVoltageTT(this) : BW_Util.getnominalVoltage(this);
 
-        byte tTier = (byte) Math.max(1, GT_Utility.getTier(nominalV));
+        byte tTier = (byte) Math.max(1, Math.min(GT_Utility.getTier(nominalV), V.length - 1));
 
         GT_Recipe tRecipe = GT_Recipe.GT_Recipe_Map.sVacuumRecipes.findRecipe(this.getBaseMetaTileEntity(), false, V[tTier], null, tInputs);
         boolean found_Recipe = false;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_Diode.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_Diode.java
@@ -124,6 +124,14 @@ public class GT_MetaTileEntity_Diode extends GT_MetaTileEntity_BasicHull {
 
     @SuppressWarnings("deprecation")
     public String[] getDescription() {
-        return new String[]{this.mDescription, StatCollector.translateToLocal("tooltip.tile.tiereddsc.0.name") + " " + ChatColorHelper.YELLOW + GT_Values.V[this.mTier], StatCollector.translateToLocal("tooltip.tile.tiereddsc.1.name") + " " + ChatColorHelper.YELLOW + this.maxAmperesIn(), StatCollector.translateToLocal("tooltip.tile.tiereddsc.2.name") + " " + ChatColorHelper.YELLOW + this.maxAmperesOut(), BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()};
+        return new String[]{
+                this.mDescription,
+                StatCollector.translateToLocal("tooltip.tile.tiereddsc.0.name") + " " +
+                        ChatColorHelper.YELLOW + GT_Utility.formatNumbers(GT_Values.V[this.mTier]),
+                StatCollector.translateToLocal("tooltip.tile.tiereddsc.1.name") + " " +
+                        ChatColorHelper.YELLOW + GT_Utility.formatNumbers(this.maxAmperesIn()),
+                StatCollector.translateToLocal("tooltip.tile.tiereddsc.2.name") + " " +
+                        ChatColorHelper.YELLOW + GT_Utility.formatNumbers(this.maxAmperesOut()),
+                BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()};
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_EnergyDistributor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_EnergyDistributor.java
@@ -29,6 +29,7 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Transformer;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.util.StatCollector;
 
 public class GT_MetaTileEntity_EnergyDistributor extends GT_MetaTileEntity_Transformer {
@@ -71,7 +72,15 @@ public class GT_MetaTileEntity_EnergyDistributor extends GT_MetaTileEntity_Trans
     }
 
     public String[] getDescription() {
-        return new String[]{StatCollector.translateToLocal("tooltip.tile.energydistributor.0.name"), StatCollector.translateToLocal("tooltip.tile.tiereddsc.0.name") + " " + ChatColorHelper.YELLOW + GT_Values.V[this.mTier], StatCollector.translateToLocal("tooltip.tile.tiereddsc.1.name") + " " + ChatColorHelper.YELLOW + this.maxAmperesIn(), StatCollector.translateToLocal("tooltip.tile.tiereddsc.2.name") + " " + ChatColorHelper.YELLOW + this.maxAmperesOut(), BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()};
+        return new String[]{
+                StatCollector.translateToLocal("tooltip.tile.energydistributor.0.name"),
+                StatCollector.translateToLocal("tooltip.tile.tiereddsc.0.name") + " "
+                        + ChatColorHelper.YELLOW + GT_Utility.formatNumbers(GT_Values.V[this.mTier]),
+                StatCollector.translateToLocal("tooltip.tile.tiereddsc.1.name") + " "
+                        + ChatColorHelper.YELLOW + GT_Utility.formatNumbers(this.maxAmperesIn()),
+                StatCollector.translateToLocal("tooltip.tile.tiereddsc.2.name") + " "
+                        + ChatColorHelper.YELLOW + GT_Utility.formatNumbers(this.maxAmperesOut()),
+                BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()};
     }
 
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_RadioHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_RadioHatch.java
@@ -250,9 +250,24 @@ public class GT_MetaTileEntity_RadioHatch extends GT_MetaTileEntity_Hatch {
     @Override
     public String[] getInfoData() {
         if (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert) != 0)
-            return new String[]{StatCollector.translateToLocal("tooltip.tile.radhatch.2.name") + " " + this.material, StatCollector.translateToLocal("tooltip.tile.radhatch.3.name") + " " + this.sievert, StatCollector.translateToLocal("tooltip.tile.radhatch.4.name") + " " + this.mass, StatCollector.translateToLocal("tooltip.tile.radhatch.5.name") + " " + +((GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert)) - this.timer % (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert) * 60)) + StatCollector.translateToLocal("tooltip.tile.radhatch.6.name") + "/" + ((GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert)) - this.timer % (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert))) / 20 + StatCollector.translateToLocal("tooltip.tile.radhatch.7.name") + "/" + ((GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert)) - this.timer % (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert))) / 20 / 60 + StatCollector.translateToLocal("tooltip.tile.radhatch.8.name") + "/" + ((GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert)) - this.timer % (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert))) / 20 / 60 / 60 + StatCollector.translateToLocal("tooltip.tile.radhatch.9.name")};
+            return new String[]{
+                    StatCollector.translateToLocal("tooltip.tile.radhatch.2.name") + " " + this.material,
+                    StatCollector.translateToLocal("tooltip.tile.radhatch.3.name") + " " + this.sievert,
+                    StatCollector.translateToLocal("tooltip.tile.radhatch.4.name") + " " + this.mass,
+                    StatCollector.translateToLocal("tooltip.tile.radhatch.5.name") + " " +
+                            ((GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert)) - this.timer % (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert) * 60)) +
+                            StatCollector.translateToLocal("tooltip.tile.radhatch.6.name") + "/" +
+                            ((GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert)) - this.timer % (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert))) / 20 +
+                            StatCollector.translateToLocal("tooltip.tile.radhatch.7.name") + "/" +
+                            ((GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert)) - this.timer % (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert))) / 20 / 60 +
+                            StatCollector.translateToLocal("tooltip.tile.radhatch.8.name") + "/" +
+                            ((GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert)) - this.timer % (GT_MetaTileEntity_RadioHatch.calcDecayTicks(this.sievert))) / 20 / 60 / 60 +
+                            StatCollector.translateToLocal("tooltip.tile.radhatch.9.name")};
         else
-            return new String[]{StatCollector.translateToLocal("tooltip.tile.radhatch.2.name") + " " + StatCollector.translateToLocal("tooltip.bw.empty.name"), StatCollector.translateToLocal("tooltip.tile.radhatch.3.name") + " " + "0", StatCollector.translateToLocal("tooltip.tile.radhatch.4.name") + " " + "0"};
+            return new String[]{
+                    StatCollector.translateToLocal("tooltip.tile.radhatch.2.name") + " " + StatCollector.translateToLocal("tooltip.bw.empty.name"),
+                    StatCollector.translateToLocal("tooltip.tile.radhatch.3.name") + " " + "0",
+                    StatCollector.translateToLocal("tooltip.tile.radhatch.4.name") + " " + "0"};
     }
 
     public boolean isSimpleMachine() {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/neiHandler/BW_NEI_BioVatHandler.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/neiHandler/BW_NEI_BioVatHandler.java
@@ -63,11 +63,11 @@ public class BW_NEI_BioVatHandler extends GT_NEI_DefaultHandler {
         int tSpecial;
         if (recipeDesc == null) {
             if (tEUt != 0) {
-                GT_NEI_DefaultHandler.drawText(10, lines[0], this.trans("152", "Total: ") + (long) tDuration * (long) tEUt + " EU", -16777216);
-                GT_NEI_DefaultHandler.drawText(10, lines[1], this.trans("153", "Usage: ") + tEUt + " EU/t", -16777216);
+                GT_NEI_DefaultHandler.drawText(10, lines[0], this.trans("152", "Total: ") + GT_Utility.formatNumbers((long) tDuration * (long) tEUt) + " EU", -16777216);
+                GT_NEI_DefaultHandler.drawText(10, lines[1], this.trans("153", "Usage: ") + GT_Utility.formatNumbers(tEUt) + " EU/t", -16777216);
                 if (this.mRecipeMap.mShowVoltageAmperageInNEI) {
-                    GT_NEI_DefaultHandler.drawText(10, lines[2], this.trans("154", "Voltage: ") + tEUt / this.mRecipeMap.mAmperage + " EU", -16777216);
-                    GT_NEI_DefaultHandler.drawText(10, lines[3], this.trans("155", "Amperage: ") + this.mRecipeMap.mAmperage, -16777216);
+                    GT_NEI_DefaultHandler.drawText(10, lines[2], this.trans("154", "Voltage: ") + GT_Utility.formatNumbers(tEUt / this.mRecipeMap.mAmperage) + " EU", -16777216);
+                    GT_NEI_DefaultHandler.drawText(10, lines[3], this.trans("155", "Amperage: ") + GT_Utility.formatNumbers(this.mRecipeMap.mAmperage), -16777216);
                 } else {
                     GT_NEI_DefaultHandler.drawText(10, lines[2], this.trans("156", "Voltage: unspecified"), -16777216);
                     GT_NEI_DefaultHandler.drawText(10, lines[3], this.trans("157", "Amperage: unspecified"), -16777216);
@@ -76,7 +76,7 @@ public class BW_NEI_BioVatHandler extends GT_NEI_DefaultHandler {
 
 
             if (tDuration > 0) {
-                GT_NEI_DefaultHandler.drawText(10, lines[4], this.trans("158", "Time: ") + String.format("%.2f " + this.trans("161", " secs"), 0.05F * (float) tDuration), -16777216);
+                GT_NEI_DefaultHandler.drawText(10, lines[4], this.trans("158", "Time: ") + GT_Utility.formatNumbers(0.05d * tDuration) + this.trans("161", " secs"), -16777216);
             }
 
             tSpecial = ((GT_NEI_DefaultHandler.CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mSpecialValue;

--- a/src/main/java/com/github/bartimaeusnek/crossmod/emt/tileentities/multi/GT_Industrial_Alchemic_Construct.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/emt/tileentities/multi/GT_Industrial_Alchemic_Construct.java
@@ -106,7 +106,7 @@ public class GT_Industrial_Alchemic_Construct extends GT_MetaTileEntity_MultiBlo
         ItemStack outputItems = null;
 
         long tVoltage = this.getMaxInputVoltage();
-        byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
+        byte tTier = (byte) Math.max(1, Math.min(GT_Utility.getTier(tVoltage), V.length - 1));
         GT_Recipe tRecipe = TCRecipeHandler.alchemicalConstructHandler.findRecipe(this.getBaseMetaTileEntity(),null,false, false, V[tTier], null, stack, tInputs);
         ItemStack helper = (ItemStack) tRecipe.mSpecialItems;
         NBTTagCompound tagCompound = helper.getTagCompound();

--- a/src/main/java/com/github/bartimaeusnek/crossmod/tectech/TecTechEnabledMulti.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/tectech/TecTechEnabledMulti.java
@@ -82,8 +82,25 @@ public interface TecTechEnabledMulti {
         }
 
         return new String[]{
-                StatCollector.translateToLocal("GT5U.multiblock.Progress") + ": "
-                        + EnumChatFormatting.GREEN + multiBlockBase.mProgresstime / 20 + EnumChatFormatting.RESET + " s / " + EnumChatFormatting.YELLOW + multiBlockBase.mMaxProgresstime / 20 + EnumChatFormatting.RESET + " s", StatCollector.translateToLocal("GT5U.multiblock.energy") + ": " + EnumChatFormatting.GREEN + storedEnergy + EnumChatFormatting.RESET + " EU / " + EnumChatFormatting.YELLOW + maxEnergy + EnumChatFormatting.RESET + " EU", StatCollector.translateToLocal("GT5U.multiblock.usage") + ": " + EnumChatFormatting.RED + -multiBlockBase.mEUt + EnumChatFormatting.RESET + " EU/t", StatCollector.translateToLocal("GT5U.multiblock.mei") + ": " + EnumChatFormatting.YELLOW + multiBlockBase.getMaxInputVoltage() + EnumChatFormatting.RESET + " EU/t(*2A) " + StatCollector.translateToLocal("GT5U.machines.tier") + ": " + EnumChatFormatting.YELLOW + GT_Values.VN[GT_Utility.getTier(multiBlockBase.getMaxInputVoltage())] + EnumChatFormatting.RESET, StatCollector.translateToLocal("GT5U.multiblock.problems") + ": " + EnumChatFormatting.RED + (multiBlockBase.getIdealStatus() - multiBlockBase.getRepairStatus()) + EnumChatFormatting.RESET + " " + StatCollector.translateToLocal("GT5U.multiblock.efficiency") + ": " + EnumChatFormatting.YELLOW + (float) multiBlockBase.mEfficiency / 100.0F + EnumChatFormatting.RESET + " %", StatCollector.translateToLocal("GT5U.multiblock.pollution") + ": " + EnumChatFormatting.GREEN + mPollutionReduction + EnumChatFormatting.RESET + " %", BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()};
+                StatCollector.translateToLocal("GT5U.multiblock.Progress") + ": " +
+                        EnumChatFormatting.GREEN + GT_Utility.formatNumbers(multiBlockBase.mProgresstime / 20) + EnumChatFormatting.RESET + " s / " +
+                        EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(multiBlockBase.mMaxProgresstime / 20) + EnumChatFormatting.RESET + " s",
+                StatCollector.translateToLocal("GT5U.multiblock.energy") + ": " +
+                        EnumChatFormatting.GREEN + GT_Utility.formatNumbers(storedEnergy) + EnumChatFormatting.RESET + " EU / " +
+                        EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(maxEnergy) + EnumChatFormatting.RESET + " EU",
+                StatCollector.translateToLocal("GT5U.multiblock.usage") + ": " +
+                        EnumChatFormatting.RED + GT_Utility.formatNumbers(-multiBlockBase.mEUt) + EnumChatFormatting.RESET + " EU/t",
+                StatCollector.translateToLocal("GT5U.multiblock.mei") + ": " +
+                        EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(multiBlockBase.getMaxInputVoltage()) + EnumChatFormatting.RESET + " EU/t(*2A) " +
+                        StatCollector.translateToLocal("GT5U.machines.tier") + ": " +
+                        EnumChatFormatting.YELLOW + GT_Values.VN[GT_Utility.getTier(multiBlockBase.getMaxInputVoltage())] + EnumChatFormatting.RESET,
+                StatCollector.translateToLocal("GT5U.multiblock.problems") + ": " +
+                        EnumChatFormatting.RED + (multiBlockBase.getIdealStatus() - multiBlockBase.getRepairStatus()) + EnumChatFormatting.RESET + " " +
+                        StatCollector.translateToLocal("GT5U.multiblock.efficiency") + ": " +
+                        EnumChatFormatting.YELLOW + (float) multiBlockBase.mEfficiency / 100.0F + EnumChatFormatting.RESET + " %",
+                StatCollector.translateToLocal("GT5U.multiblock.pollution") + ": " +
+                        EnumChatFormatting.GREEN + mPollutionReduction + EnumChatFormatting.RESET + " %",
+                BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()};
     }
 
 }

--- a/src/main/java/com/github/bartimaeusnek/crossmod/tectech/tileentites/tiered/TT_MetaTileEntity_LowPowerLaserBox.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/tectech/tileentites/tiered/TT_MetaTileEntity_LowPowerLaserBox.java
@@ -28,6 +28,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.util.GT_Utility;
 
 public class TT_MetaTileEntity_LowPowerLaserBox extends TT_Abstract_LowPowerLaserThingy {
 
@@ -145,6 +146,9 @@ public class TT_MetaTileEntity_LowPowerLaserBox extends TT_Abstract_LowPowerLase
 
     @Override
     public String[] getDescription() {
-        return new String[]{"Like a Tranformer... but for LAZORZ", "Transferrate: " + ChatColorHelper.YELLOW + this.getTotalPower() + ChatColorHelper.WHITE + " EU/t", BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()};
+        return new String[]{
+                "Like a Tranformer... but for LAZORZ",
+                "Transfer rate: " + ChatColorHelper.YELLOW + GT_Utility.formatNumbers(this.getTotalPower()) + ChatColorHelper.WHITE + " EU/t",
+                BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()};
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/crossmod/tectech/tileentites/tiered/TT_MetaTileEntity_LowPowerLaserDynamo.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/tectech/tileentites/tiered/TT_MetaTileEntity_LowPowerLaserDynamo.java
@@ -27,6 +27,7 @@ import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_H
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
@@ -70,7 +71,8 @@ public class TT_MetaTileEntity_LowPowerLaserDynamo extends GT_MetaTileEntity_Hat
     public String[] getDescription() {
         return new String[]{
                 this.mDescription,
-                StatCollector.translateToLocal("gt.blockmachines.hatch.dynamotunnel.desc.1") + ": " + EnumChatFormatting.YELLOW + this.getTotalPower() + EnumChatFormatting.RESET + " EU/t",
+                StatCollector.translateToLocal("gt.blockmachines.hatch.dynamotunnel.desc.1") + ": "
+                        + EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(this.getTotalPower()) + EnumChatFormatting.RESET + " EU/t",
                 BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()
         };
     }

--- a/src/main/java/com/github/bartimaeusnek/crossmod/tectech/tileentites/tiered/TT_MetaTileEntity_LowPowerLaserHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/tectech/tileentites/tiered/TT_MetaTileEntity_LowPowerLaserHatch.java
@@ -27,6 +27,7 @@ import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_H
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
@@ -45,7 +46,8 @@ public class TT_MetaTileEntity_LowPowerLaserHatch extends GT_MetaTileEntity_Hatc
     public String[] getDescription() {
         return new String[]{
                 this.mDescription,
-                StatCollector.translateToLocal("gt.blockmachines.hatch.energytunnel.desc.1") + ": " + EnumChatFormatting.YELLOW + this.getTotalPower() + EnumChatFormatting.RESET + " EU/t",
+                StatCollector.translateToLocal("gt.blockmachines.hatch.energytunnel.desc.1") + ": "
+                        + EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(this.getTotalPower()) + EnumChatFormatting.RESET + " EU/t",
                 BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get()
         };
     }


### PR DESCRIPTION
Changes:
 * Add number formatting to portable scanner output and tooltips.
 * Fix too high voltage causing array OOB (as reported in issue).

See:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8346

I loaded up the game and looked at a bunch of tooltips and scanner output, but there are too many changes to test thoroughly. Adding formatting should be fairly safe though.