### PR TITLE
stop generating unused entries in GregTech.lang

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/configs/ConfigHandler.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/configs/ConfigHandler.java
@@ -70,6 +70,9 @@ public class ConfigHandler {
 
     public static byte maxTierRoss;
 
+    public static boolean disableBoltedBlocksCasing = false;
+    public static boolean disableReboltedBlocksCasing = false;
+
     private static final int[][] METAFORTIERS_ENERGY = {
             {100, 101, 102, 105},
             {1110, 1115, 1120, 1127},
@@ -122,6 +125,8 @@ public class ConfigHandler {
         ConfigHandler.cutoffTier = ConfigHandler.c.get("System", "Tier to nerf circuits", 5, "This switch sets the lowest unnerfed Circuit Recipe Tier. -1 to disable it completely.",-1, VOLTAGE_NAMES.length).getInt(5);
         ConfigHandler.cutoffTier = (ConfigHandler.cutoffTier == -1 ? VOLTAGE_NAMES.length : ConfigHandler.cutoffTier);
         ConfigHandler.disableExtraGassesForEBF = ConfigHandler.c.get("System", "Disable Extra Gases for EBF", false, "This switch disables extra gas recipes for the EBF, i.e. Xenon instead of Nitrogen").getBoolean(false);
+        ConfigHandler.disableBoltedBlocksCasing = ConfigHandler.c.get("System", "Disable Bolted Casings", false, "This switch disable the generation of bolted casings").getBoolean(false);
+        ConfigHandler.disableReboltedBlocksCasing = ConfigHandler.c.get("System", "Disable Rebolted Casings", false, "This switch disable the generation of rebolted casings").getBoolean(false);
 
         ConfigHandler.mbWaterperSec = ConfigHandler.c.get("Singleblocks", "mL Water per Sec for the StirlingPump", 150).getInt(150);
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_MetaGeneratedBlocks_Casing.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_MetaGeneratedBlocks_Casing.java
@@ -88,7 +88,7 @@ public class BW_MetaGeneratedBlocks_Casing extends BW_MetaGenerated_Blocks imple
     protected void doRegistrationStuff(Werkstoff tMaterial) {
         GregTech_API.registerMachineBlock(this, -1);
         if (tMaterial == null) return;
-        if (tMaterial.hasItemType(OrePrefixes.plate) && tMaterial.hasItemType(OrePrefixes.gearGtSmall)) {
+        if ((tMaterial.doesOreDictedItemExists(OrePrefixes.plate) && tMaterial.doesOreDictedItemExists(OrePrefixes.gearGtSmall)) || (tMaterial.hasItemType(OrePrefixes.plate) && tMaterial.hasItemType(OrePrefixes.gearGtSmall))) {
             Optional.of(tMaterial)
                     .ifPresent(pMaterial ->
                             GT_LanguageManager.addStringLocalization(

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_MetaGeneratedBlocks_Casing.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_MetaGeneratedBlocks_Casing.java
@@ -87,13 +87,16 @@ public class BW_MetaGeneratedBlocks_Casing extends BW_MetaGenerated_Blocks imple
     @Override
     protected void doRegistrationStuff(Werkstoff tMaterial) {
         GregTech_API.registerMachineBlock(this, -1);
-        Optional.ofNullable(tMaterial)
-                .ifPresent(pMaterial ->
+        if (tMaterial == null) return;
+        if (tMaterial.hasItemType(OrePrefixes.plate) && tMaterial.hasItemType(OrePrefixes.gearGtSmall)) {
+            Optional.of(tMaterial)
+                    .ifPresent(pMaterial ->
                             GT_LanguageManager.addStringLocalization(
                                     this.getUnlocalizedName() + "." + pMaterial.getmID() + ".name",
                                     _prefixes.mLocalizedMaterialPre + pMaterial.getDefaultName() + _prefixes.mLocalizedMaterialPost
                             )
-                );
+                    );
+        }
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
@@ -27,6 +27,7 @@ import com.github.bartimaeusnek.bartworks.API.SideReference;
 import com.github.bartimaeusnek.bartworks.API.WerkstoffAdderRegistry;
 import com.github.bartimaeusnek.bartworks.MainMod;
 import com.github.bartimaeusnek.bartworks.client.renderer.BW_Renderer_Block_Ores;
+import com.github.bartimaeusnek.bartworks.common.configs.ConfigHandler;
 import com.github.bartimaeusnek.bartworks.system.material.CircuitGeneration.BW_CircuitsLoader;
 import com.github.bartimaeusnek.bartworks.system.material.GT_Enhancement.GTMetaItemEnhancer;
 import com.github.bartimaeusnek.bartworks.system.material.processingLoaders.AdditionalRecipes;
@@ -1729,8 +1730,10 @@ public class WerkstoffLoader {
         GameRegistry.registerBlock(WerkstoffLoader.BWOres, BW_MetaGeneratedBlock_Item.class, "bw.blockores.01");
         GameRegistry.registerBlock(WerkstoffLoader.BWSmallOres, BW_MetaGeneratedBlock_Item.class, "bw.blockores.02");
         GameRegistry.registerBlock(WerkstoffLoader.BWBlocks, BW_MetaGeneratedBlock_Item.class, "bw.werkstoffblocks.01");
-        GameRegistry.registerBlock(WerkstoffLoader.BWBlockCasings, BW_MetaGeneratedBlock_Item.class, "bw.werkstoffblockscasing.01");
-        GameRegistry.registerBlock(WerkstoffLoader.BWBlockCasingsAdvanced, BW_MetaGeneratedBlock_Item.class, "bw.werkstoffblockscasingadvanced.01");
+        if (!ConfigHandler.disableBoltedBlocksCasing)
+            GameRegistry.registerBlock(WerkstoffLoader.BWBlockCasings, BW_MetaGeneratedBlock_Item.class, "bw.werkstoffblockscasing.01");
+        if (!ConfigHandler.disableReboltedBlocksCasing)
+            GameRegistry.registerBlock(WerkstoffLoader.BWBlockCasingsAdvanced, BW_MetaGeneratedBlock_Item.class, "bw.werkstoffblockscasingadvanced.01");
 
         GTMetaItemEnhancer.addAdditionalOreDictToForestry();
         GTMetaItemEnhancer.init();


### PR DESCRIPTION
kiwi233 has complained to me about bartworks generating casing block lang key for all materials, which most of them are useless.
so i make it only generate lang key for proper material.