### PR TITLE
optimize parallel algorithm

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -59,6 +59,7 @@ import net.minecraftforge.fluids.FluidStack;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.getMultiOutput;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.handleParallelRecipe;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlockAdder;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
@@ -162,9 +163,9 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
     }
 
     @SuppressWarnings("rawtypes")
-    public ArrayList TTTunnels = new ArrayList<>();
+    public ArrayList<Object> TTTunnels = new ArrayList<>();
     @SuppressWarnings("rawtypes")
-    public ArrayList TTMultiAmp = new ArrayList<>();
+    public ArrayList<Object> TTMultiAmp = new ArrayList<>();
 
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
@@ -397,45 +398,10 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
             int tCurrentPara = handleParallelRecipe(tRecipe, tFluids, tInputs, (int) tMaxPara);
             processed = tCurrentPara;
             found_Recipe = true;
-            if (tRecipe.mOutputs != null) {
-                for (int i = 0; i < tRecipe.mOutputs.length; i++) {
-                    tCurrentPara = processed;
-                    while (tCurrentPara > 0 && tRecipe.getOutput(i) != null) {
-                        int maxSize = tRecipe.getOutput(i).getMaxStackSize();
-                        if (tCurrentPara <= maxSize) {
-                            outputItems.add(GT_Utility.copyAmount(maxSize, tRecipe.getOutput(i)));
-                            tCurrentPara -= maxSize;
-                        }
-                        else {
-                            outputItems.add(GT_Utility.copyAmount(tCurrentPara, tRecipe.getOutput(i)));
-                            tCurrentPara = 0;
-                        }
-                    }
-                }
-            }
-            if (tRecipe.mFluidOutputs != null) {
-                for (int i = 0; i < tRecipe.mFluidOutputs.length; i++) {
-                    while (tRecipe.getFluidOutput(i) != null) {
-                        FluidStack tOutputFluid = new FluidStack(tRecipe.getFluidOutput(i).getFluid(), tRecipe.getFluidOutput(i).amount * processed);
-                        outputFluids.add(tOutputFluid);
-                    }
-                }
-            }
+            Object[] Outputs = getMultiOutput(tRecipe, tCurrentPara);
+            outputFluids = (ArrayList<FluidStack>) Outputs[0];
+            outputItems = (ArrayList<ItemStack>) Outputs[1];
         }
-
-       /* while (this.getStoredInputs().size() > 0 && processed < ConfigHandler.megaMachinesMax) {
-            if (this.mHeatingCapacity >= tRecipe.mSpecialValue && (precutRecipeVoltage * (processed + 1)) < nominalV && tRecipe.isRecipeInputEqual(true, tFluids, tInputs)) {
-                found_Recipe = true;
-                for (int i = 0; i < tRecipe.mOutputs.length; i++) {
-                    outputItems.add(tRecipe.getOutput(i));
-                }
-                for (int i = 0; i < tRecipe.mFluidOutputs.length; i++) {
-                    outputFluids.add(tRecipe.getFluidOutput(i));
-                }
-                ++processed;
-            } else
-                break;
-        }*/
 
         if (found_Recipe) {
             this.mEfficiency = (10000 - (this.getIdealStatus() - this.getRepairStatus()) * 1000);

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -28,6 +28,7 @@ import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
 import com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference;
 import com.github.bartimaeusnek.bartworks.util.BW_Util;
 import com.github.bartimaeusnek.bartworks.util.MegaUtils;
+import com.github.bartimaeusnek.bartworks.util.Pair;
 import com.github.bartimaeusnek.crossmod.tectech.TecTechEnabledMulti;
 import com.github.bartimaeusnek.crossmod.tectech.helper.TecTechUtils;
 import com.github.bartimaeusnek.crossmod.tectech.tileentites.tiered.LowPowerLaser;
@@ -398,9 +399,9 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
             int tCurrentPara = handleParallelRecipe(tRecipe, tFluids, tInputs, (int) tMaxPara);
             processed = tCurrentPara;
             found_Recipe = true;
-            Object[] Outputs = getMultiOutput(tRecipe, tCurrentPara);
-            outputFluids = (ArrayList<FluidStack>) Outputs[0];
-            outputItems = (ArrayList<ItemStack>) Outputs[1];
+            Pair<ArrayList<FluidStack>, ArrayList<ItemStack>> Outputs = getMultiOutput(tRecipe, tCurrentPara);
+            outputFluids = Outputs.getKey();
+            outputItems = Outputs.getValue();
         }
 
         if (found_Recipe) {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
@@ -230,7 +230,7 @@ public class GT_TileEntity_MegaDistillTower extends GT_MetaTileEntity_Distillati
             for (FluidStack tFluid : tFluids) {
                 ArrayList<FluidStack> outputFluids = new ArrayList<>();
                 ArrayList<ItemStack> outputItems = new ArrayList<>();
-                Object[] Outputs;
+                Pair<ArrayList<FluidStack>, ArrayList<ItemStack>> Outputs;
                 int processed = 0;
                 boolean found_Recipe = false;
                 GT_Recipe tRecipe = GT_Recipe.GT_Recipe_Map.sDistillationRecipes.findRecipe(this.getBaseMetaTileEntity(), false, GT_Values.V[tTier], new FluidStack[]{tFluid});
@@ -241,8 +241,8 @@ public class GT_TileEntity_MegaDistillTower extends GT_MetaTileEntity_Distillati
                     int tCurrentPara = handleParallelRecipe(tRecipe, new FluidStack[]{tFluid}, null, (int) tMaxPara);
                     processed = tCurrentPara;
                     Outputs = getMultiOutput(tRecipe, tCurrentPara);
-                    outputFluids = (ArrayList<FluidStack>) Outputs[0];
-                    outputItems = (ArrayList<ItemStack>) Outputs[1];
+                    outputFluids = Outputs.getKey();
+                    outputItems = Outputs.getValue();
                 }
 
                 if (!found_Recipe)

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
@@ -27,6 +27,7 @@ import com.github.bartimaeusnek.bartworks.common.configs.ConfigHandler;
 import com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference;
 import com.github.bartimaeusnek.bartworks.util.BW_Util;
 import com.github.bartimaeusnek.bartworks.util.MegaUtils;
+import com.github.bartimaeusnek.bartworks.util.Pair;
 import com.github.bartimaeusnek.crossmod.tectech.TecTechEnabledMulti;
 import com.github.bartimaeusnek.crossmod.tectech.helper.TecTechUtils;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
@@ -115,9 +116,9 @@ public class GT_TileEntity_MegaVacuumFreezer extends GT_MetaTileEntity_VacuumFre
             long tMaxPara = Math.min(ConfigHandler.megaMachinesMax, nominalV / tRecipe.mEUt);
             int tCurrentPara = handleParallelRecipe(tRecipe, tInputFluids, tInputs, (int) tMaxPara);
             processed = tCurrentPara;
-            Object[] Outputs = getMultiOutput(tRecipe, tCurrentPara);
-            outputFluids = (ArrayList<FluidStack>) Outputs[0];
-            outputItems = (ArrayList<ItemStack>) Outputs[1];
+            Pair<ArrayList<FluidStack>, ArrayList<ItemStack>> Outputs = getMultiOutput(tRecipe, tCurrentPara);
+            outputFluids = Outputs.getKey();
+            outputItems = Outputs.getValue();
         }
 
         if (found_Recipe) {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
@@ -45,6 +45,7 @@ import net.minecraftforge.fluids.FluidStack;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.getMultiOutput;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.handleParallelRecipe;
 import static gregtech.api.enums.GT_Values.V;
 
@@ -114,49 +115,10 @@ public class GT_TileEntity_MegaVacuumFreezer extends GT_MetaTileEntity_VacuumFre
             long tMaxPara = Math.min(ConfigHandler.megaMachinesMax, nominalV / tRecipe.mEUt);
             int tCurrentPara = handleParallelRecipe(tRecipe, tInputFluids, tInputs, (int) tMaxPara);
             processed = tCurrentPara;
-            if (tRecipe.mOutputs != null) {
-                for (int i = 0; i < tRecipe.mOutputs.length; i++) {
-                    tCurrentPara = processed;
-                    while (tCurrentPara > 0 && tRecipe.getOutput(i) != null) {
-                        int maxSize = tRecipe.getOutput(i).getMaxStackSize();
-                        if (tCurrentPara <= maxSize) {
-                            outputItems.add(GT_Utility.copyAmount(maxSize, tRecipe.getOutput(i)));
-                            tCurrentPara -= maxSize;
-                        }
-                        else {
-                            outputItems.add(GT_Utility.copyAmount(tCurrentPara, tRecipe.getOutput(i)));
-                            tCurrentPara = 0;
-                        }
-                    }
-                }
-            }
-            if (tRecipe.mFluidOutputs != null) {
-                for (int i = 0; i < tRecipe.mFluidOutputs.length; i++) {
-                    while (tRecipe.getFluidOutput(i) != null) {
-                        FluidStack tOutputFluid = new FluidStack(tRecipe.getFluidOutput(i).getFluid(), tRecipe.getFluidOutput(i).amount * processed);
-                        outputFluids.add(tOutputFluid);
-                    }
-                }
-            }
+            Object[] Outputs = getMultiOutput(tRecipe, tCurrentPara);
+            outputFluids = (ArrayList<FluidStack>) Outputs[0];
+            outputItems = (ArrayList<ItemStack>) Outputs[1];
         }
-
-        /*while ((this.getStoredInputs().size() > 0 || this.getStoredFluids().size() > 0) && processed < ConfigHandler.megaMachinesMax) {
-            if (tRecipe != null && ((long) tRecipe.mEUt * (processed + 1)) < nominalV && tRecipe.isRecipeInputEqual(true, tInputFluids, tInputs)) {
-                found_Recipe = true;
-                if (tRecipe.mOutputs != null) {
-                    for (int i = 0; i < tRecipe.mOutputs.length; i++) {
-                        outputItems.add(tRecipe.getOutput(i));
-                    }
-                }
-                if (tRecipe.mFluidOutputs != null) {
-                    for (int i = 0; i < tRecipe.mFluidOutputs.length; i++) {
-                        outputFluids.add(tRecipe.getFluidOutput(i));
-                    }
-                }
-                ++processed;
-            } else
-                break;
-        }*/
 
         if (found_Recipe) {
             this.mEfficiency = (10000 - (this.getIdealStatus() - this.getRepairStatus()) * 1000);

--- a/src/main/java/com/github/bartimaeusnek/bartworks/util/RecipeFinderForParallel.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/util/RecipeFinderForParallel.java
@@ -1,0 +1,106 @@
+package com.github.bartimaeusnek.bartworks.util;
+
+import gregtech.api.util.GT_Recipe;
+import gregtech.api.util.GT_Utility;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import java.util.HashMap;
+
+public class RecipeFinderForParallel {
+
+    /**
+        This method is used for mega multis which have extremely high parallel.<BR>
+        Never use it for non parallel machines, it will have worse performance.<BR>
+     */
+
+    public static int handleParallelRecipe(GT_Recipe aRecipe, FluidStack[] aFluidInputs, ItemStack[] aItemStacks, int aMaxParallel) {
+        HashMap<Integer, Integer> tCompressedFluidInput = compressFluid(aFluidInputs);
+        HashMap<Integer, Integer> tCompressedItemInput = compressItem(aItemStacks);
+        HashMap<Integer, Integer> tCompressedFluidRecipe = compressFluid(aRecipe.mFluidInputs);
+        HashMap<Integer, Integer> tCompressedItemRecipe = compressItem(aRecipe.mInputs);
+        int tCurrentPara = aMaxParallel;
+        for (int tFluid : tCompressedFluidRecipe.keySet()) {
+            if (tCompressedFluidInput.containsKey(tFluid) && tCompressedFluidRecipe.get(tFluid) != 0) {
+                tCurrentPara = Math.min(tCurrentPara, tCompressedFluidInput.get(tFluid) / tCompressedFluidRecipe.get(tFluid));
+            }
+        }
+        for (int tItem : tCompressedItemRecipe.keySet()) {
+            if (tCompressedItemInput.containsKey(tItem) && tCompressedItemRecipe.get(tItem) != 0) {
+                tCurrentPara = Math.min(tCurrentPara, tCompressedItemInput.get(tItem) / tCompressedItemRecipe.get(tItem));
+            }
+        }
+
+        for (int tFluid : tCompressedFluidRecipe.keySet()) {
+            int tOldSize = tCompressedFluidRecipe.get(tFluid);
+            tCompressedFluidRecipe.put(tFluid, tOldSize * tCurrentPara);
+        }
+        for (int tItem : tCompressedItemRecipe.keySet()) {
+            int tOldSize = tCompressedItemRecipe.get(tItem);
+            tCompressedItemRecipe.put(tItem, tOldSize * tCurrentPara);
+        }
+
+        for (FluidStack tFluid : aFluidInputs) {
+            if (tFluid != null && tCompressedFluidRecipe.containsKey(tFluid.getFluidID())) {
+                if (tFluid.amount >= tCompressedFluidRecipe.get(tFluid.getFluidID())) {
+                    tFluid.amount -= tCompressedFluidRecipe.get(tFluid.getFluidID());
+                    tCompressedItemRecipe.remove(tFluid.getFluidID());
+                }
+                else {
+                    tCompressedFluidRecipe.put(tFluid.getFluidID(), tCompressedFluidRecipe.get(tFluid.getFluidID()) - tFluid.amount);
+                    tFluid.amount = 0;
+                }
+            }
+        }
+
+        for (ItemStack tItem : aItemStacks) {
+            if (tItem != null && tCompressedItemRecipe.containsKey(GT_Utility.stackToInt(tItem))) {
+                if (tItem.stackSize >= tCompressedItemRecipe.get(GT_Utility.stackToInt(tItem))) {
+                    tItem.stackSize -= tCompressedItemRecipe.get(GT_Utility.stackToInt(tItem));
+                    tCompressedItemRecipe.remove(GT_Utility.stackToInt(tItem));
+                }
+                else {
+                    tCompressedItemRecipe.put(GT_Utility.stackToInt(tItem), tCompressedItemRecipe.get(GT_Utility.stackToInt(tItem)) - tItem.stackSize);
+                    tItem.stackSize = 0;
+                }
+            }
+        }
+        return tCurrentPara;
+    }
+
+    public static HashMap<Integer, Integer> compressItem(ItemStack[] aItemStacks) {
+        HashMap<Integer, Integer> tCompressed = new HashMap<>();
+        for (ItemStack tItem : aItemStacks) {
+            if (tItem != null) {
+                int tItemID = GT_Utility.stackToInt(tItem);
+                int tItemSize = tItem.stackSize;
+                if (tCompressed.containsKey(tItemID)) {
+                    int tOldSize = tCompressed.get(tItemID);
+                    tCompressed.put(tItemID, tOldSize + tItemSize);
+                }
+                else {
+                    tCompressed.put(tItemID, tItemSize);
+                }
+            }
+        }
+        return tCompressed;
+    }
+
+    public static HashMap<Integer, Integer> compressFluid(FluidStack[] aFluidStack) {
+        HashMap<Integer, Integer> tCompressed = new HashMap<>();
+        for (FluidStack tFluid : aFluidStack) {
+            if (tFluid != null) {
+                int tFluidID = tFluid.getFluidID();
+                int tFluidSize = tFluid.amount;
+                if (tCompressed.containsKey(tFluidID)) {
+                    int tOldSize = tCompressed.get(tFluidID);
+                    tCompressed.put(tFluidID, tOldSize + tFluidSize);
+                }
+                else {
+                    tCompressed.put(tFluidID, tFluidSize);
+                }
+            }
+        }
+        return tCompressed;
+    }
+}

--- a/src/main/java/com/github/bartimaeusnek/bartworks/util/RecipeFinderForParallel.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/util/RecipeFinderForParallel.java
@@ -16,6 +16,8 @@ public class RecipeFinderForParallel {
      */
 
     public static int handleParallelRecipe(GT_Recipe aRecipe, FluidStack[] aFluidInputs, ItemStack[] aItemStacks, int aMaxParallel) {
+        if (aFluidInputs == null) aFluidInputs = new FluidStack[0];
+        if (aItemStacks == null) aItemStacks = new ItemStack[0];
         HashMap<Integer, Integer> tCompressedFluidInput = compressFluid(aFluidInputs);
         HashMap<Integer, Integer> tCompressedItemInput = compressItem(aItemStacks);
         HashMap<Integer, Integer> tCompressedFluidRecipe = compressFluid(aRecipe.mFluidInputs);
@@ -69,11 +71,11 @@ public class RecipeFinderForParallel {
         return tCurrentPara;
     }
 
-    public static Object[] getMultiOutput(GT_Recipe aRecipe, int aPall) {
+    public static Pair<ArrayList<FluidStack>, ArrayList<ItemStack>> getMultiOutput(GT_Recipe aRecipe, int aPall) {
         ArrayList<FluidStack> tFluidList = new ArrayList<>();
         ArrayList<ItemStack> tItemList = new ArrayList<>();
         if (aRecipe == null)
-            return new Object[]{tFluidList, tItemList};
+            return new Pair<>(tFluidList, tItemList);
         if (aRecipe.mFluidOutputs != null && aRecipe.mFluidOutputs.length > 0) {
             for (FluidStack tFluid : aRecipe.mFluidOutputs) {
                 if (tFluid != null && tFluid.amount > 0) {
@@ -93,9 +95,7 @@ public class RecipeFinderForParallel {
                 }
             }
         }
-        return new Object[]{
-                tFluidList, tItemList
-        };
+        return new Pair<>(tFluidList, tItemList);
     }
 
     public static HashMap<Integer, Integer> compressItem(ItemStack[] aItemStacks) {
@@ -104,13 +104,7 @@ public class RecipeFinderForParallel {
             if (tItem != null) {
                 int tItemID = GT_Utility.stackToInt(tItem);
                 int tItemSize = tItem.stackSize;
-                if (tCompressed.containsKey(tItemID)) {
-                    int tOldSize = tCompressed.get(tItemID);
-                    tCompressed.put(tItemID, tOldSize + tItemSize);
-                }
-                else {
-                    tCompressed.put(tItemID, tItemSize);
-                }
+                tCompressed.merge(tItemID, tItemSize, Integer::sum);
             }
         }
         return tCompressed;
@@ -122,13 +116,7 @@ public class RecipeFinderForParallel {
             if (tFluid != null) {
                 int tFluidID = tFluid.getFluidID();
                 int tFluidSize = tFluid.amount;
-                if (tCompressed.containsKey(tFluidID)) {
-                    int tOldSize = tCompressed.get(tFluidID);
-                    tCompressed.put(tFluidID, tOldSize + tFluidSize);
-                }
-                else {
-                    tCompressed.put(tFluidID, tFluidSize);
-                }
+                tCompressed.merge(tFluidID, tFluidSize, Integer::sum);
             }
         }
         return tCompressed;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/util/RecipeFinderForParallel.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/util/RecipeFinderForParallel.java
@@ -5,6 +5,7 @@ import gregtech.api.util.GT_Utility;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 
 public class RecipeFinderForParallel {
@@ -66,6 +67,35 @@ public class RecipeFinderForParallel {
             }
         }
         return tCurrentPara;
+    }
+
+    public static Object[] getMultiOutput(GT_Recipe aRecipe, int aPall) {
+        ArrayList<FluidStack> tFluidList = new ArrayList<>();
+        ArrayList<ItemStack> tItemList = new ArrayList<>();
+        if (aRecipe == null)
+            return new Object[]{tFluidList, tItemList};
+        if (aRecipe.mFluidOutputs != null && aRecipe.mFluidOutputs.length > 0) {
+            for (FluidStack tFluid : aRecipe.mFluidOutputs) {
+                if (tFluid != null && tFluid.amount > 0) {
+                    tFluidList.add(new FluidStack(tFluid.getFluid(), tFluid.amount * aPall));
+                }
+            }
+        }
+        if (aRecipe.mOutputs != null && aRecipe.mOutputs.length > 0) {
+            for (ItemStack tItem : aRecipe.mOutputs) {
+                if (tItem != null && tItem.stackSize > 0) {
+                    int tAmount = tItem.stackSize * aPall;
+                    while (tAmount > tItem.getMaxStackSize()) {
+                        tItemList.add(GT_Utility.copyAmount(tItem.getMaxStackSize(), tItem));
+                        tAmount -= tItem.getMaxStackSize();
+                    }
+                    tItemList.add(GT_Utility.copyAmount(tAmount, tItem));
+                }
+            }
+        }
+        return new Object[]{
+                tFluidList, tItemList
+        };
     }
 
     public static HashMap<Integer, Integer> compressItem(ItemStack[] aItemStacks) {


### PR DESCRIPTION
i did a optimization for the parallel algorithm of mega mechines. directly using division instead of loop to get the parallel recipe amount.
when i tested in MEBF (ticking 256 steel), it uses arv 67,000ns, worst 233,000ns. (the old loop algorithm is arv 180,000ns, worst 310,000ns). it can save more time when the machine have more parallel recipes, especially for mega multis. however, it may perform worse than the origin loop when machine has less 8 parallel recipes.