### PR TITLE
Add config for BW pollution values

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/configs/ConfigHandler.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/configs/ConfigHandler.java
@@ -75,7 +75,7 @@ public class ConfigHandler {
     public static boolean disableReboltedBlocksCasing = false;
 
     public static int pollutionHeatedWaterPumpSecond = 5;
-    public static int basePollutionMBFTick = 5120;
+    public static int basePollutionMBFTick = 20;
 
     private static final int[][] METAFORTIERS_ENERGY = {
             {100, 101, 102, 105},

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/configs/ConfigHandler.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/configs/ConfigHandler.java
@@ -25,8 +25,6 @@ package com.github.bartimaeusnek.bartworks.common.configs;
 
 import com.github.bartimaeusnek.ASM.BWCoreTransformer;
 import com.github.bartimaeusnek.bartworks.API.API_ConfigValues;
-import com.github.bartimaeusnek.bartworks.API.SideReference;
-import jdk.nashorn.internal.runtime.regexp.joni.Config;
 import net.minecraftforge.common.config.Configuration;
 
 import java.util.Arrays;
@@ -75,7 +73,7 @@ public class ConfigHandler {
     public static boolean disableReboltedBlocksCasing = false;
 
     public static int pollutionHeatedWaterPumpSecond = 5;
-    public static int basePollutionMBFTick = 20;
+    public static int basePollutionMBFSecond = 400;
 
     private static final int[][] METAFORTIERS_ENERGY = {
             {100, 101, 102, 105},
@@ -140,7 +138,7 @@ public class ConfigHandler {
         ConfigHandler.bioVatMaxParallelBonus = ConfigHandler.c.get("Multiblocks","BioVat Maximum Bonus on Recipes", 1000,"This are the maximum parallel Operations the BioVat can do, when the output is half full.").getInt(1000);
 
         ConfigHandler.pollutionHeatedWaterPumpSecond = ConfigHandler.c.get("Pollution", "Pollution produced per second by the water pump", ConfigHandler.pollutionHeatedWaterPumpSecond, "How much should the Simple Stirling Water Pump produce pollution per second").getInt(ConfigHandler.pollutionHeatedWaterPumpSecond);
-        ConfigHandler.basePollutionMBFTick = ConfigHandler.c.get("Pollution", "Pollution produced per tick by the MBF per ingot", ConfigHandler.basePollutionMBFTick,"How much should the MBF produce pollution per tick per ingot. Then it'll be multiplied by the amount of ingots done in parallel").getInt(ConfigHandler.basePollutionMBFTick);
+        ConfigHandler.basePollutionMBFSecond = ConfigHandler.c.get("Pollution", "Pollution produced per tick by the MBF per ingot", ConfigHandler.basePollutionMBFSecond,"How much should the MBF produce pollution per tick per ingot. Then it'll be multiplied by the amount of ingots done in parallel").getInt(ConfigHandler.basePollutionMBFSecond);
 
         if (ConfigHandler.IDOffset == 0) {
             ConfigHandler.IDOffset = 12600;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/configs/ConfigHandler.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/configs/ConfigHandler.java
@@ -26,6 +26,7 @@ package com.github.bartimaeusnek.bartworks.common.configs;
 import com.github.bartimaeusnek.ASM.BWCoreTransformer;
 import com.github.bartimaeusnek.bartworks.API.API_ConfigValues;
 import com.github.bartimaeusnek.bartworks.API.SideReference;
+import jdk.nashorn.internal.runtime.regexp.joni.Config;
 import net.minecraftforge.common.config.Configuration;
 
 import java.util.Arrays;
@@ -72,6 +73,9 @@ public class ConfigHandler {
 
     public static boolean disableBoltedBlocksCasing = false;
     public static boolean disableReboltedBlocksCasing = false;
+
+    public static int pollutionHeatedWaterPumpSecond = 5;
+    public static int basePollutionMBFTick = 5120;
 
     private static final int[][] METAFORTIERS_ENERGY = {
             {100, 101, 102, 105},
@@ -134,6 +138,9 @@ public class ConfigHandler {
         ConfigHandler.DEHPDirectSteam = ConfigHandler.c.get("Multiblocks", "DEHP Direct Steam Mode", false, "This switch enables the Direct Steam Mode of the DEHP. If enabled it will take in Waterand output steam. If disabled it will Input IC2Coolant and output hot coolant").getBoolean(false);
         ConfigHandler.megaMachinesMax = ConfigHandler.c.get("Multiblocks", "Mega Machines Maximum Recipes per Operation", 256, "This changes the Maximum Recipes per Operation to the specified Valure").getInt(256);
         ConfigHandler.bioVatMaxParallelBonus = ConfigHandler.c.get("Multiblocks","BioVat Maximum Bonus on Recipes", 1000,"This are the maximum parallel Operations the BioVat can do, when the output is half full.").getInt(1000);
+
+        ConfigHandler.pollutionHeatedWaterPumpSecond = ConfigHandler.c.get("Pollution", "Pollution produced per second by the water pump", ConfigHandler.pollutionHeatedWaterPumpSecond, "How much should the Simple Stirling Water Pump produce pollution per second").getInt(ConfigHandler.pollutionHeatedWaterPumpSecond);
+        ConfigHandler.basePollutionMBFTick = ConfigHandler.c.get("Pollution", "Pollution produced per tick by the MBF per ingot", ConfigHandler.basePollutionMBFTick,"How much should the MBF produce pollution per tick per ingot. Then it'll be multiplied by the amount of ingots done in parallel").getInt(ConfigHandler.basePollutionMBFTick);
 
         if (ConfigHandler.IDOffset == 0) {
             ConfigHandler.IDOffset = 12600;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/classic/BW_TileEntity_HeatedWaterPump.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/classic/BW_TileEntity_HeatedWaterPump.java
@@ -160,7 +160,7 @@ public class BW_TileEntity_HeatedWaterPump extends TileEntity implements ITileDr
         Optional.ofNullable(this.worldObj).ifPresent(e -> {
                     if (e.getTotalWorldTime() % 20 == 0) {
                         Optional.ofNullable(e.getChunkFromBlockCoords(this.xCoord, this.zCoord)).ifPresent(c ->
-                                GT_Pollution.addPollution(c, 5)
+                                GT_Pollution.addPollution(c, ConfigHandler.pollutionHeatedWaterPumpSecond)
                         );
                     }
                 }
@@ -331,7 +331,11 @@ public class BW_TileEntity_HeatedWaterPump extends TileEntity implements ITileDr
     public String[] getInfoData() {
         return new String[]{
                 StatCollector.translateToLocal("tooltip.tile.waterpump.0.name") + " " +
-                        GT_Utility.formatNumbers(ConfigHandler.mbWaterperSec) + StatCollector.translateToLocal("tooltip.tile.waterpump.1.name"),
+                        GT_Utility.formatNumbers(ConfigHandler.mbWaterperSec) +
+                        String.format(
+                                StatCollector.translateToLocal("tooltip.tile.waterpump.1.name"),
+                                ConfigHandler.pollutionHeatedWaterPumpSecond
+                        ),
                 StatCollector.translateToLocal("tooltip.tile.waterpump.2.name")};
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -121,7 +121,7 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
 
     private int mHeatingCapacity;
     private byte glasTier;
-    private int polPtick = ConfigHandler.basePollutionMBFTick*ConfigHandler.megaMachinesMax;
+    private int polPtick = ConfigHandler.basePollutionMBFSecond / 20 * ConfigHandler.megaMachinesMax;
 
     public GT_TileEntity_MegaBlastFurnace(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -426,7 +426,7 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
 
             this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-            this.polPtick = ConfigHandler.basePollutionMBFTick * processed;
+            this.polPtick = ConfigHandler.basePollutionMBFSecond / 20 * processed;
             this.mOutputItems = new ItemStack[outputItems.size()];
             this.mOutputItems = outputItems.toArray(this.mOutputItems);
             this.mOutputFluids = new FluidStack[outputFluids.size()];

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -121,7 +121,7 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
 
     private int mHeatingCapacity;
     private byte glasTier;
-    private int polPtick = super.getPollutionPerTick(null) * ConfigHandler.megaMachinesMax;
+    private int polPtick = ConfigHandler.basePollutionMBFTick*ConfigHandler.megaMachinesMax;
 
     public GT_TileEntity_MegaBlastFurnace(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -426,7 +426,7 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_MetaTileEntity_ElectricBl
 
             this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
 
-            this.polPtick = super.getPollutionPerTick(null) * processed;
+            this.polPtick = ConfigHandler.basePollutionMBFTick * processed;
             this.mOutputItems = new ItemStack[outputItems.size()];
             this.mOutputItems = outputItems.toArray(this.mOutputItems);
             this.mOutputFluids = new FluidStack[outputFluids.size()];

--- a/src/main/resources/assets/bartworks/lang/en_US.lang
+++ b/src/main/resources/assets/bartworks/lang/en_US.lang
@@ -97,7 +97,7 @@ tooltip.labparts.7.name=A DNA Flask containing:
 tooltip.labparts.8.name=A Plasmid Cell containing:
 
 tooltip.tile.waterpump.0.name=Produces
-tooltip.tile.waterpump.1.name=L/s Water when fueled. Causes 5 Pollution per second.
+tooltip.tile.waterpump.1.name=L/s Water when fueled. Causes %d Pollution per second.
 tooltip.tile.waterpump.2.name=Must be placed on the Ground.
 
 tooltip.tile.mbf.0.name=Controller Block for the Mega Blast Furnace;Size(WxHxD): 15x20x15 (Hollow);Controller: 3rd Layer Middle Center;Inner 13x18x13 Heating Coils (Hollow);Outer 15x18x15 Borosilicate Glass;The glass tier limits the Energy Input tier;1+ Input Hatch/Bus (Any casing);1+ Output Hatch/Bus (Any casing);1+ Energy Hatch (Any casing);1x Maintenance Hatch (Any casing);13x13 Muffler Hatches (Top middle);Heat Proof Machine Casings for the outer 15x15 (Layer 20);1+ Output Hatch to recover CO2/CO/SO2 (optional, any top layer casing);    Recovery scales with Muffler Hatch tier;Heat Proof Machine Casings for Base;Each 900K over the min. Heat Capacity grants 5% speedup (multiplicatively);Each 1800K over the min. Heat Capacity allows for one upgraded overclock;Upgraded overclocks reduce recipe time to 25% and increase EU/t to 400%;Causes maximum


### PR DESCRIPTION
This adds a config entry for the Simple Stirling Water Pump and the MBF. Btw i saw that the pollution tooltip of the MBF is actually the max it can produce (400 pollution/s * 256 parrallel) so it's equals to 4 stacks of EBF instead of 1. Maybe we want to divide it by 4?