### PR TITLE
Windmill fixes

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_Windmill.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_Windmill.java
@@ -107,7 +107,8 @@ public class GT_TileEntity_Windmill extends GT_MetaTileEntity_MultiBlockBase {
         if (tRecipe == null)
             return false;
         if (tRecipe.getOutput(0) != null) {
-            aStack.stackSize--;
+            // Decrease input stack by appropriate amount (Not always 1)
+            tRecipe.isRecipeInputEqual(true, null, aStack);
             this.mOutputItems[0] = tRecipe.getOutput(0);
 
             if (new XSTR().nextInt(2) == 0) {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_Windmill.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_Windmill.java
@@ -125,7 +125,6 @@ public class GT_TileEntity_Windmill extends GT_MetaTileEntity_MultiBlockBase {
                         BW_Util.checkStackAndPrefix(this.mOutputItems[0]) && GT_OreDictUnificator.getAssociation(this.mOutputItems[0]).mMaterial.mMaterial == Materials.Sugar ||
                         BW_Util.checkStackAndPrefix(this.mOutputItems[0]) && GT_OreDictUnificator.getAssociation(this.mOutputItems[0]).mMaterial.mMaterial == Materials.Wheat ||
                         BW_Util.checkStackAndPrefix(this.mOutputItems[0]) && GT_OreDictUnificator.getAssociation(this.mOutputItems[0]).mMaterial.mMaterial == Materials.Wood ||
-                        BW_Util.checkStackAndPrefix(this.mOutputItems[0]) && GT_OreDictUnificator.getAssociation(this.mOutputItems[0]).mMaterial.mMaterial == Materials.Clay ||
                         BW_Util.checkStackAndPrefix(this.mOutputItems[0]) && GT_OreDictUnificator.getAssociation(this.mOutputItems[0]).mMaterial.mMaterial == Materials.Ash ||
                         BW_Util.checkStackAndPrefix(this.mOutputItems[0]) && GT_OreDictUnificator.getAssociation(this.mOutputItems[0]).mMaterial.mMaterial == Materials.Snow ||
                         BW_Util.checkStackAndPrefix(this.mOutputItems[0]) && GT_OreDictUnificator.getAssociation(this.mOutputItems[0]).mMaterial.mMaterial == Materials.Stone ||


### PR DESCRIPTION
This PR has 2 small Windmill fixes :
- The windmill produces more clay dust than the pulverizer does, which allows for infinite clay (in theory) when combined with a mixer. Removing the extra output makes it use the normal pulverizer recipe.
- Fixed windmill not using up the right amount of input items. For example the 2 flint to flint dust recipe only consumed 1 flint.