### PR TITLE
fix material disappear

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -123,6 +123,7 @@ public class StaticRecipeChangeLoaders {
 
     public static void unificationRecipeEnforcer() {
         for (Werkstoff werkstoff : Werkstoff.werkstoffHashSet) {
+            StaticRecipeChangeLoaders.runMaterialLinker(werkstoff);
             if (werkstoff.getGenerationFeatures().enforceUnification) {
 
                 if (werkstoff.contains(NOBLE_GAS))
@@ -258,6 +259,24 @@ public class StaticRecipeChangeLoaders {
                 for (ItemStack stack : OreDictionary.getOres(prefixes + werkstoff.getVarName())) {
                     GT_OreDictUnificator.addAssociation(prefixes, werkstoff.getBridgeMaterial(), stack, false);
                     GT_OreDictUnificator.getAssociation(stack).mUnificationTarget = werkstoff.get(prefixes);
+                }
+            }
+    }
+
+    private static void runMaterialLinker(Werkstoff werkstoff) {
+        if (werkstoff.getType() == Werkstoff.Types.ELEMENT) {
+            if (werkstoff.getBridgeMaterial() != null) {
+                werkstoff.getBridgeMaterial().mElement = Element.get(werkstoff.getToolTip());
+                Element.get(werkstoff.getToolTip()).mLinkedMaterials = new ArrayList<>();
+                Element.get(werkstoff.getToolTip()).mLinkedMaterials.add(werkstoff.getBridgeMaterial());
+            }
+        }
+
+        for (OrePrefixes prefixes : OrePrefixes.values())
+            if (werkstoff.hasItemType(prefixes)) {
+                GT_OreDictUnificator.set(prefixes, werkstoff.getBridgeMaterial(), werkstoff.get(prefixes), true, true);
+                for (ItemStack stack : OreDictionary.getOres(prefixes + werkstoff.getVarName())) {
+                    GT_OreDictUnificator.addAssociation(prefixes, werkstoff.getBridgeMaterial(), stack, false);
                 }
             }
     }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -273,7 +273,7 @@ public class StaticRecipeChangeLoaders {
         }
 
         for (OrePrefixes prefixes : OrePrefixes.values())
-            if (werkstoff.hasItemType(prefixes)) {
+            if (werkstoff.hasItemType(prefixes) && werkstoff.getBridgeMaterial() != null) {
                 GT_OreDictUnificator.set(prefixes, werkstoff.getBridgeMaterial(), werkstoff.get(prefixes), true, true);
                 for (ItemStack stack : OreDictionary.getOres(prefixes + werkstoff.getVarName())) {
                     GT_OreDictUnificator.addAssociation(prefixes, werkstoff.getBridgeMaterial(), stack, false);

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
@@ -1630,13 +1630,11 @@ public class WerkstoffLoader {
                     WerkstoffLoader.molten.put(werkstoff, FluidRegistry.getFluid(werkstoff.getDefaultName()));
                 }
             }
-            /*
             for (OrePrefixes p : values())
-                if (!werkstoff.getGenerationFeatures().enforceUnification && (werkstoff.getGenerationFeatures().toGenerate & p.mMaterialGenerationBits) != 0 && OreDictHandler.getItemStack(werkstoff.getDefaultName(), p, 1) != null) {
-                    DebugLog.log("Found: " + (p + werkstoff.getVarName()) + " in oreDict, disable and reroute my Items to that, also add a Tooltip.");
+                if (Materials.get(werkstoff.getDefaultName()) != null && Materials.get(werkstoff.getDefaultName()).mMetaItemSubID != -1 && (werkstoff.getGenerationFeatures().toGenerate & p.mMaterialGenerationBits) != 0 && OreDictHandler.getItemStack(werkstoff.getDefaultName(), p, 1) != null) {
+                    DebugLog.log("Found: " + (p + werkstoff.getVarName()) + " in GT material system, disable and reroute my Items to that, also add a Tooltip.");
                     werkstoff.getGenerationFeatures().setBlacklist(p);
                 }
-             */
             WerkstoffLoader.toGenerateGlobal = (WerkstoffLoader.toGenerateGlobal | werkstoff.getGenerationFeatures().toGenerate);
         }
         DebugLog.log("GlobalGeneration: " + WerkstoffLoader.toGenerateGlobal);

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
@@ -1630,11 +1630,13 @@ public class WerkstoffLoader {
                     WerkstoffLoader.molten.put(werkstoff, FluidRegistry.getFluid(werkstoff.getDefaultName()));
                 }
             }
+            /*
             for (OrePrefixes p : values())
                 if (!werkstoff.getGenerationFeatures().enforceUnification && (werkstoff.getGenerationFeatures().toGenerate & p.mMaterialGenerationBits) != 0 && OreDictHandler.getItemStack(werkstoff.getDefaultName(), p, 1) != null) {
                     DebugLog.log("Found: " + (p + werkstoff.getVarName()) + " in oreDict, disable and reroute my Items to that, also add a Tooltip.");
                     werkstoff.getGenerationFeatures().setBlacklist(p);
                 }
+             */
             WerkstoffLoader.toGenerateGlobal = (WerkstoffLoader.toGenerateGlobal | werkstoff.getGenerationFeatures().toGenerate);
         }
         DebugLog.log("GlobalGeneration: " + WerkstoffLoader.toGenerateGlobal);

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/ToolLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/ToolLoader.java
@@ -101,7 +101,7 @@ public class ToolLoader implements IWerkstoffRunnable {
         GT_ModHandler.addCraftingRecipe(GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(GT_MetaGenerated_Tool_01.SCREWDRIVER_LV, 1, werkstoff.getBridgeMaterial(), Materials.Steel, new long[]{50000L, 32L, 1L, -1L}), GT_ModHandler.RecipeBits.DISMANTLEABLE | GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"PdX", "MGS", "GBP", 'X', stickLong.get(werkstoff.getBridgeMaterial()), 'M', ItemList.Electric_Motor_LV.get(1L), 'S', screw.get(Materials.Steel), 'P', plate.get(Materials.Steel), 'G', gearGtSmall.get(Materials.Steel), 'B', ItemList.Battery_RE_LV_Sodium.get(1L)});
 
         GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(toolHeadHammer, werkstoff.getBridgeMaterial(), 1L), GT_Proxy.tBits, new Object[]{"II ", "IIh", "II ", 'P', plate.get(werkstoff.getBridgeMaterial()), 'I', ingot.get(werkstoff.getBridgeMaterial())});
-        if (werkstoff.hasItemType(plateDouble)) {
+        if (werkstoff.hasItemType(plateDouble) && werkstoff.hasItemType(cellMolten)) {
             GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(turbineBlade, werkstoff.getBridgeMaterial(), 1L), GT_Proxy.tBits, new Object[]{"fPd", "SPS", " P ", 'P', plateDouble.get(werkstoff.getBridgeMaterial()), 'S', screw.get(werkstoff.getBridgeMaterial())});
             GT_Values.RA.addExtruderRecipe(werkstoff.get(ingot, 6), ItemList.Shape_Extruder_Turbine_Blade.get(0), werkstoff.get(turbineBlade, 1), (int) werkstoff.getStats().getMass() / 2 * 20, 120);
             GT_Values.RA.addFluidSolidifierRecipe(ItemList.Shape_Mold_Turbine_Blade.get(0), werkstoff.getMolten(864), werkstoff.get(turbineBlade, 1), (int) werkstoff.getStats().getMass() * 20, 120);


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9544
make Werkstoff won't stop generate item when a item with the same oredict exist, and add them to `GT_OreDictUnificator.addAssociation` so it can accept other items with the same oredict.