### PR TITLE
Fix Werkstoff localization failure

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
@@ -29,6 +29,7 @@ import com.github.bartimaeusnek.bartworks.util.MurmurHash3;
 import com.github.bartimaeusnek.bartworks.util.NonNullWrappedHashMap;
 import com.github.bartimaeusnek.bartworks.util.Pair;
 import com.github.bartimaeusnek.crossmod.thaumcraft.util.ThaumcraftHandler;
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SubTag;
@@ -73,9 +74,9 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
     private final HashSet<SubTag> SUBTAGS = new HashSet<>();
     private byte[] rgb = new byte[3];
     private final String defaultName;
-    private final String localizedName;
+    private String localizedName;
     private String toolTip;
-    private final String localizedToolTip;
+    private String localizedToolTip;
 
     private Werkstoff.Stats stats;
     private final Werkstoff.Types type;
@@ -183,7 +184,9 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
 
         this.mID = (short) mID;
         this.defaultName = defaultName;
-        this.localizedName = GT_LanguageManager.addStringLocalization(String.format("bw.werkstoff.%05d.name", this.mID), defaultName);
+        GregTech_API.sAfterGTPreload.add(() -> {
+            this.localizedName = GT_LanguageManager.addStringLocalization(String.format("bw.werkstoff.%05d.name", this.mID), defaultName);
+        });
         this.stats = stats;
         this.type = type;
         this.generationFeatures = generationFeatures;
@@ -220,7 +223,9 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
 //        if (this.toolTip.length() > 25)
 //            this.toolTip = "The formula is to long...";
 
-        this.localizedToolTip = GT_LanguageManager.addStringLocalization(String.format("bw.werkstoff.%05d.tooltip", this.mID), toolTip);
+        GregTech_API.sAfterGTPreload.add(() -> {
+            this.localizedToolTip = GT_LanguageManager.addStringLocalization(String.format("bw.werkstoff.%05d.tooltip", this.mID), toolTip);
+        });
 
         if (this.stats.protons == 0) {
             long tmpprotons = 0;


### PR DESCRIPTION
`Werkstoff` will be instantiated before `GregTech_API.sPreloadFinished`, at which point the `GT_LanguageManager` is not yet loaded