### PR TITLE
Add customizable EBF gas recipe time and gas consumption multipliers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1644894948
+//version: 1652851397
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -6,12 +6,11 @@ Also, you may replace this file at any time if there is an update available.
 Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle for updates.
 */
 
-import org.gradle.internal.logging.text.StyledTextOutput
-import org.gradle.internal.logging.text.StyledTextOutputFactory
-import org.gradle.internal.logging.text.StyledTextOutput.Style
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.internal.logging.text.StyledTextOutput.Style
+import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 import java.util.concurrent.TimeUnit
 
@@ -45,13 +44,14 @@ plugins {
     id 'eclipse'
     id 'scala'
     id 'maven-publish'
-    id 'org.jetbrains.kotlin.jvm'        version '1.5.30' apply false
-    id 'org.jetbrains.kotlin.kapt'       version '1.5.30' apply false
+    id 'org.jetbrains.kotlin.jvm'        version '1.5.30'       apply false
+    id 'org.jetbrains.kotlin.kapt'       version '1.5.30'       apply false
+    id 'com.google.devtools.ksp'         version '1.5.30-1.0.0' apply false
     id 'org.ajoberstar.grgit'            version '4.1.1'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
-    id 'com.palantir.git-version'        version '0.13.0' apply false
+    id 'com.palantir.git-version'        version '0.13.0'       apply false
     id 'de.undercouch.download'          version '5.0.1'
-    id 'com.github.gmazzo.buildconfig'   version '3.0.3'  apply false
+    id 'com.github.gmazzo.buildconfig'   version '3.0.3'        apply false
 }
 
 if (project.file('.git/HEAD').isFile()) {
@@ -104,6 +104,7 @@ checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
 boolean noPublishedSources = project.findProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
+boolean usesMixinDebug = project.findProperty('usesMixinDebug') ?: project.usesMixins.toBoolean()
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
@@ -214,13 +215,17 @@ else {
 def arguments = []
 def jvmArguments = []
 
-if(usesMixins.toBoolean()) {
+if (usesMixins.toBoolean()) {
     arguments += [
-            "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
+        "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
     ]
-    jvmArguments += [
-            "-Dmixin.debug.countInjections=true", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true"
-    ]
+    if (usesMixinDebug.toBoolean()) {
+        jvmArguments += [
+            "-Dmixin.debug.countInjections=true",
+            "-Dmixin.debug.verbose=true",
+            "-Dmixin.debug.export=true"
+        ]
+    }
 }
 
 minecraft {
@@ -312,18 +317,23 @@ def refMap = "${tasks.compileJava.temporaryDir}" + File.separator + mixingConfig
 def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
 task generateAssets {
-    if(usesMixins.toBoolean()) {
-        getFile("/src/main/resources/mixins." + modId + ".json").text = """{
+    if (usesMixins.toBoolean()) {
+        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json");
+        if (!mixinConfigFile.exists()) {
+            mixinConfigFile.text = """{
   "required": true,
   "minVersion": "0.7.11",
   "package": "${modGroup}.${mixinsPackage}",
   "plugin": "${modGroup}.${mixinPlugin}",
   "refmap": "${mixingConfigRefMap}",
   "target": "@env(DEFAULT)",
-  "compatibilityLevel": "JAVA_8"
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "client": [],
+  "server": []
 }
-
 """
+        }
     }
 }
 
@@ -559,7 +569,7 @@ publishing {
                 artifact source: shadowJar, classifier: ""
             }
             if(!noPublishedSources) {
-                artifact source: sourcesJar, classifier: "src"
+                artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
             if (apiPackage) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,10 @@
 // Add your dependencies here
 
 dependencies {
-    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.40.42:dev")
-    compile("com.github.GTNewHorizons:StructureLib:1.0.15:dev")
+    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.40.49:dev")
+    compile("com.github.GTNewHorizons:StructureLib:1.0.16:dev")
     compile("com.github.GTNewHorizons:TecTech:4.10.18:dev")
-    compile("com.github.GTNewHorizons:NotEnoughItems:2.2.12-GTNH:dev")
+    compile("com.github.GTNewHorizons:NotEnoughItems:2.2.15-GTNH:dev")
     compile("com.github.GTNewHorizons:TinkersConstruct:1.9.0.13-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.3:dev")
     compile("com.github.GTNewHorizons:CodeChickenCore:1.1.3:dev")
@@ -14,7 +14,7 @@ dependencies {
     }
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
-    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-75-GTNH:dev") {
+    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-86-GTNH:dev") {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:AppleCore:3.1.9:dev") {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
@@ -960,12 +960,13 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
             if (this.neutrons != that.neutrons) return false;
             if (this.electrons != that.electrons) return false;
             if (Math.abs(this.ebfGasRecipeTimeMultiplier - that.ebfGasRecipeTimeMultiplier) > 1.0e-6D) return false;
+            if (Math.abs(this.ebfGasRecipeConsumedAmountMultiplier - that.ebfGasRecipeConsumedAmountMultiplier) > 1.0e-6D) return false;
             return this.quality == that.quality;
         }
 
         @Override
         public int hashCode() {
-            return MurmurHash3.murmurhash3_x86_32(ByteBuffer.allocate(49).put(this.quality).putInt(this.boilingPoint).putInt(this.meltingPoint).putLong(this.protons).putLong(this.neutrons).putLong(this.electrons).putLong(this.mass).array(), 0, 49, 31);
+            return MurmurHash3.murmurhash3_x86_32(ByteBuffer.allocate(49).put(this.quality).putInt(this.boilingPoint).putInt(this.meltingPoint).putLong(this.protons).putLong(this.neutrons).putLong(this.electrons).putLong(this.mass).putDouble(this.ebfGasRecipeTimeMultiplier).putDouble(this.ebfGasRecipeConsumedAmountMultiplier).array(), 0, 49, 31);
         }
 
         public Werkstoff.Stats setMass(long mass) {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
@@ -22,6 +22,7 @@
 
 package com.github.bartimaeusnek.bartworks.system.material;
 
+import com.github.bartimaeusnek.bartworks.common.loaders.StaticRecipeChangeLoaders;
 import com.github.bartimaeusnek.bartworks.system.oredict.OreDictHandler;
 import com.github.bartimaeusnek.bartworks.util.BW_ColorUtil;
 import com.github.bartimaeusnek.bartworks.util.BW_Util;
@@ -850,6 +851,33 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
             return this;
         }
 
+        public double getEbfGasRecipeTimeMultiplier() {
+            return this.ebfGasRecipeTimeMultiplier;
+        }
+
+        /**
+         * The generated EBF recipes using this gas will have their duration multiplied by this number.
+         * If set to a negative value, the default proton count-based logic is used.
+         * For GT Materials gases, add the overrides to {@link StaticRecipeChangeLoaders#addEBFGasRecipes()}
+         */
+        public Werkstoff.Stats setEbfGasRecipeTimeMultiplier(double timeMultiplier) {
+            this.ebfGasRecipeTimeMultiplier = timeMultiplier;
+            return this;
+        }
+
+        public double getEbfGasRecipeConsumedAmountMultiplier() {
+            return this.ebfGasRecipeConsumedAmountMultiplier;
+        }
+
+        /**
+         * The generated EBF recipes using this gas will have the amount of gas consumed multiplied by this number.
+         * For GT Materials gases, add the overrides to {@link StaticRecipeChangeLoaders#addEBFGasRecipes()}
+         */
+        public Werkstoff.Stats setEbfGasRecipeConsumedAmountMultiplier(double amountMultiplier) {
+            this.ebfGasRecipeConsumedAmountMultiplier = amountMultiplier;
+            return this;
+        }
+
         public int getDurOverride() {
             return durOverride;
         }
@@ -886,6 +914,8 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
         private long neutrons;
         private long electrons;
         private long mass;
+        private double ebfGasRecipeTimeMultiplier = -1.0;
+        private double ebfGasRecipeConsumedAmountMultiplier = 1.0;
 
         float durMod = 1f;
 
@@ -929,6 +959,7 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
             if (this.protons != that.protons) return false;
             if (this.neutrons != that.neutrons) return false;
             if (this.electrons != that.electrons) return false;
+            if (Math.abs(this.ebfGasRecipeTimeMultiplier - that.ebfGasRecipeTimeMultiplier) > 1.0e-6D) return false;
             return this.quality == that.quality;
         }
 


### PR DESCRIPTION
Allows to adjust EBF recipe time multipliers and gas amount consumed per gas type, while maintaining the old atomic number based system for the previous recipes.

@Steelux8