### PR TITLE
Buff Extreme Industrial Greenhouse's Speed and Lower IC2 Tier to LuV

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -157,21 +157,21 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             addInfo("[IC2] You need to also input block that is required under the crop").
             addInfo("Output mode: machine will take planted seeds and output them").
             addInfo("-------------------- NORMAL CROPS --------------------").
-            addInfo("Minimal tier: EV").
+            addInfo("Minimal tier: " + ChatColorHelper.DARKPURPLE + "EV").
             addInfo("Starting with 1 slot").
             addInfo("Every slot gives 64 crops").
-            addInfo("Every tier past EV adds additional 2 slots").
+            addInfo("Every tier past " + ChatColorHelper.DARKPURPLE + "EV" + ChatColorHelper.GRAY + " adds additional 2 slots").
             addInfo("Base process time: 5 sec").
-            addInfo("Process time is divided by number of tiers past HV (Minimum 1 sec)").
+            addInfo("Process time is divided by number of tiers past " + ChatColorHelper.GOLD + "HV" + ChatColorHelper.GRAY + " (Minimum 1 sec)").
             addInfo("All crops are grown at the end of the operation").
             addInfo("Will automatically craft seeds if they are not dropped").
             addInfo("1 Fertilizer per 1 crop +200%").
             addInfo("-------------------- IC2    CROPS --------------------").
-            addInfo("Minimal tier: LuV").
-            addInfo("Need LuV glass tier").
+            addInfo("Minimal tier: " + ChatColorHelper.LIGHT_PURPLE + "LuV").
+            addInfo("Need " + ChatColorHelper.LIGHT_PURPLE + "LuV" + ChatColorHelper.GRAY + " glass tier").
             addInfo("Starting with 4 slots").
             addInfo("Every slot gives 1 crop").
-            addInfo("Every tier past LuV, slots are multiplied by 4").
+            addInfo("Every tier past " + ChatColorHelper.LIGHT_PURPLE + "LuV" + ChatColorHelper.GRAY + ", slots are multiplied by 4").
             addInfo("Process time: 5 sec").
             addInfo("All crops are accelerated by x32 times").
             addInfo("1 Fertilizer per 1 crop +10%").

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2022 kuba6000
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.github.bartimaeusnek.bartworks.common.tileentities.multis;
 
 import com.github.bartimaeusnek.bartworks.API.BorosilicateGlass;
@@ -274,8 +291,6 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
         buildPiece(STRUCTURE_PIECE_MAIN, itemStack, b, 2, 5, 0);
     }
 
-
-
     @Override
     public boolean isCorrectMachinePart(ItemStack itemStack) {
         return true;
@@ -371,7 +386,6 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
         this.updateSlots();
         return true;
     }
-
 
     @Override
     public boolean checkMachine(IGregTechTileEntity iGregTechTileEntity, ItemStack itemStack) {
@@ -838,6 +852,5 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             return count;
         }
     }
-
-
+    
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -51,6 +51,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemSeeds;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
@@ -80,6 +81,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
     private int waterusage = 0;
     private static final int CASING_INDEX = 49;
     private static final String STRUCTURE_PIECE_MAIN = "main";
+    private static final Item forestryfertilizer = GameRegistry.findItem("Forestry", "fertilizerCompound");
     private static final IStructureDefinition<GT_TileEntity_ExtremeIndustrialGreenhouse> STRUCTURE_DEFINITION = StructureDefinition.<GT_TileEntity_ExtremeIndustrialGreenhouse>builder()
         .addShape(STRUCTURE_PIECE_MAIN, transpose(new String[][] {
             {"ccccc", "ccccc", "ccccc", "ccccc", "ccccc"},
@@ -345,7 +347,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
         ArrayList<ItemStack> inputs = getStoredInputs();
         for(ItemStack i : inputs){
             if(( i.getItem() == Items.dye && i.getItemDamage() == 15) ||
-                (i.getItem() == GameRegistry.findItem("Forestry", "fertilizerCompound")) ||
+                (forestryfertilizer != null && (i.getItem() == forestryfertilizer)) ||
                 (GT_Utility.areStacksEqual(i, Ic2Items.fertilizer)))
             {
                 int used = Math.min(i.stackSize, maxboost - boost);
@@ -852,5 +854,5 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             return count;
         }
     }
-    
+
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -167,11 +167,11 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             addInfo("Will automatically craft seeds if they are not dropped").
             addInfo("1 Fertilizer per 1 crop +200%").
             addInfo("-------------------- IC2    CROPS --------------------").
-            addInfo("Minimal tier: UV").
-            addInfo("Need UV glass tier").
+            addInfo("Minimal tier: LUV").
+            addInfo("Need LUV glass tier").
             addInfo("Starting with 4 slots").
             addInfo("Every slot gives 1 crop").
-            addInfo("Every tier past UV, slots are multiplied by 4").
+            addInfo("Every tier past LUV, slots are multiplied by 4").
             addInfo("Process time: 5 sec").
             addInfo("All crops are accelerated by x32 times").
             addInfo("1 Fertilizer per 1 crop +10%").
@@ -285,10 +285,10 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
     public boolean checkRecipe(ItemStack itemStack) {
         long v = this.getMaxInputVoltage();
         int tier = GT_Utility.getTier(v);
-        if(tier < (isIC2Mode ? 8 : 4))
+        if(tier < (isIC2Mode ? 6 : 4))
             mMaxSlots = 0;
         else if(isIC2Mode)
-            mMaxSlots = 4 << (2 * (tier - 8));
+            mMaxSlots = 4 << (2 * (tier - 6));
         else
             mMaxSlots = (tier - 4) * 2 + 1;
         if(mStorage.size() > mMaxSlots)
@@ -345,7 +345,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
 
         if(isIC2Mode)
         {
-            if(glasTier < 8)
+            if(glasTier < 6)
                 return false;
             this.mMaxProgresstime = 100;
             List<ItemStack> outputs = new ArrayList<>();

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -167,11 +167,11 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             addInfo("Will automatically craft seeds if they are not dropped").
             addInfo("1 Fertilizer per 1 crop +200%").
             addInfo("-------------------- IC2    CROPS --------------------").
-            addInfo("Minimal tier: LUV").
-            addInfo("Need LUV glass tier").
+            addInfo("Minimal tier: LuV").
+            addInfo("Need LuV glass tier").
             addInfo("Starting with 4 slots").
             addInfo("Every slot gives 1 crop").
-            addInfo("Every tier past LUV, slots are multiplied by 4").
+            addInfo("Every tier past LuV, slots are multiplied by 4").
             addInfo("Process time: 5 sec").
             addInfo("All crops are accelerated by x32 times").
             addInfo("1 Fertilizer per 1 crop +10%").

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -158,6 +158,10 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
         return (d, r, f) -> d.offsetY == 0 && r.isNotRotated() && f.isNotFlipped();
     }
 
+    private static String tierString(int tier){
+        return GT_Values.TIER_COLORS[tier] + GT_Values.VN[tier] + ChatColorHelper.RESET + ChatColorHelper.GRAY;
+    }
+
     @Override
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
@@ -176,21 +180,21 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             addInfo("[IC2] You need to also input block that is required under the crop").
             addInfo("Output mode: machine will take planted seeds and output them").
             addInfo("-------------------- NORMAL CROPS --------------------").
-            addInfo("Minimal tier: " + ChatColorHelper.DARKPURPLE + "EV").
+            addInfo("Minimal tier: " + tierString(4)).
             addInfo("Starting with 1 slot").
             addInfo("Every slot gives 64 crops").
-            addInfo("Every tier past " + ChatColorHelper.DARKPURPLE + "EV" + ChatColorHelper.GRAY + ", slots are multiplied by 2").
+            addInfo("Every tier past " + tierString(4) + ", slots are multiplied by 2").
             addInfo("Base process time: 5 sec").
-            addInfo("Process time is divided by number of tiers past " + ChatColorHelper.GOLD + "HV" + ChatColorHelper.GRAY + " (Minimum 1 sec)").
+            addInfo("Process time is divided by number of tiers past " + tierString(3) + " (Minimum 1 sec)").
             addInfo("All crops are grown at the end of the operation").
             addInfo("Will automatically craft seeds if they are not dropped").
             addInfo("1 Fertilizer per 1 crop +200%").
             addInfo("-------------------- IC2    CROPS --------------------").
-            addInfo("Minimal tier: " + ChatColorHelper.LIGHT_PURPLE + "LuV").
-            addInfo("Need " + ChatColorHelper.LIGHT_PURPLE + "LuV" + ChatColorHelper.GRAY + " glass tier").
+            addInfo("Minimal tier: " + tierString(6)).
+            addInfo("Need " + tierString(6) + " glass tier").
             addInfo("Starting with 4 slots").
             addInfo("Every slot gives 1 crop").
-            addInfo("Every tier past " + ChatColorHelper.LIGHT_PURPLE + "LuV" + ChatColorHelper.GRAY + ", slots are multiplied by 4").
+            addInfo("Every tier past " + tierString(6) + ", slots are multiplied by 4").
             addInfo("Process time: 5 sec").
             addInfo("All crops are accelerated by x32 times").
             addInfo("1 Fertilizer per 1 crop +10%").

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -179,7 +179,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             addInfo("Minimal tier: " + ChatColorHelper.DARKPURPLE + "EV").
             addInfo("Starting with 1 slot").
             addInfo("Every slot gives 64 crops").
-            addInfo("Every tier past " + ChatColorHelper.DARKPURPLE + "EV" + ChatColorHelper.GRAY + " adds additional 2 slots").
+            addInfo("Every tier past " + ChatColorHelper.DARKPURPLE + "EV" + ChatColorHelper.GRAY + ", slots are multiplied by 2").
             addInfo("Base process time: 5 sec").
             addInfo("Process time is divided by number of tiers past " + ChatColorHelper.GOLD + "HV" + ChatColorHelper.GRAY + " (Minimum 1 sec)").
             addInfo("All crops are grown at the end of the operation").
@@ -307,7 +307,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
         else if(isIC2Mode)
             mMaxSlots = 4 << (2 * (tier - 6));
         else
-            mMaxSlots = (tier - 4) * 2 + 1;
+            mMaxSlots = 1 << (tier - 4);
         if(mStorage.size() > mMaxSlots)
         {
             // Void if user just downgraded power


### PR DESCRIPTION
Lowered IC2 mode tier to LuV from UV
Now in normal mode you get x2 slots every tier past EV (instead of +2)
Now you can input fertilizer to get more outputs (up to 400% more)
IC2 +10% per fertilizer per crop per operation
NORMAL +200% per fertilizer per crop per operation