### PR TITLE
Fix tooltip wierdness

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
@@ -70,6 +70,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.isAir;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlockAnyMeta;
@@ -189,7 +190,7 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
             addInputHatch("Any casing", 1).
             addOutputHatch("Any casing", 1).
             addEnergyHatch("Any casing", 1).
-            toolTipFinisher("Bartworks");
+            toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_DEHP.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_DEHP.java
@@ -47,6 +47,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS;
 import static gregtech.api.enums.GT_Values.VN;
 
 public class GT_TileEntity_DEHP extends GT_MetaTileEntity_DrillerBase {
@@ -131,7 +132,7 @@ public class GT_TileEntity_DEHP extends GT_MetaTileEntity_DrillerBase {
                 .addInputBus("Mining Pipes, optional, any base casing")
                 .addInputHatch("Any base casing")
                 .addOutputHatch("Any base casing")
-                .toolTipFinisher(BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get());
+                .toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
@@ -48,6 +48,7 @@ import net.minecraftforge.fluids.FluidStack;
 import java.util.ArrayList;
 
 import static com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry.BW_BLOCKS;
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static gregtech.api.enums.GT_Values.V;
@@ -154,7 +155,7 @@ public class GT_TileEntity_ElectricImplosionCompressor extends GT_MetaTileEntity
             addInputBus("Any bottom casing", 1).
             addOutputBus("Any bottom casing", 1).
             addEnergyHatch("Bottom and top middle", 2).
-            toolTipFinisher("Bartworks");
+            toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -47,6 +47,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import java.util.*;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_VIA_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.enums.Textures.BlockIcons.*;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_DISTILLATION_TOWER_GLOW;
@@ -188,7 +189,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             addOutputBus("Any casing", 1).
             addInputHatch("Any casing", 1).
             addEnergyHatch("Any casing", 1).
-            toolTipFinisher("Added by " + ChatColorHelper.GOLD + "kuba6000" + ChatColorHelper.RESET + ChatColorHelper.GREEN + " via " + BW_Tooltip_Reference.BW);
+            toolTipFinisher(MULTIBLOCK_ADDED_VIA_BARTWORKS.apply(ChatColorHelper.GOLD + "kuba6000"));
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_HTGR.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_HTGR.java
@@ -58,6 +58,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_VIA_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdderOptional;
@@ -161,7 +162,7 @@ public class GT_TileEntity_HTGR extends GT_MetaTileEntity_EnhancedMultiBlockBase
                 .addOutputHatch("Any bottom layer casing", 1)
                 .addEnergyHatch("Any bottom layer casing", 1)
                 .addMaintenanceHatch("Any bottom layer casing", 1)
-                .toolTipFinisher("Added by " + ChatColorHelper.GOLD + "kuba6000" + ChatColorHelper.RESET + " via " + BW_Tooltip_Reference.BW);
+                .toolTipFinisher(MULTIBLOCK_ADDED_VIA_BARTWORKS.apply(ChatColorHelper.GOLD + "kuba6000"));
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ManualTrafo.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ManualTrafo.java
@@ -41,6 +41,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
 import static com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry.BW_BLOCKS;
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.enums.GT_Values.V;
 import static gregtech.api.enums.Textures.BlockIcons.*;
@@ -147,7 +148,7 @@ public class GT_TileEntity_ManualTrafo extends GT_MetaTileEntity_EnhancedMultiBl
             .addEnergyHatch("Touching Transformer-Winding Blocks", 3)
             .addDynamoHatch("Touching Transformer-Winding Blocks", 3)
             .addStructureInfo("Hatches touching Transformer-Winding Blocks must be tiered from bottom to top")
-            .toolTipFinisher("Bartworks");
+            .toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_THTR.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_THTR.java
@@ -55,6 +55,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdderOptional;
@@ -157,7 +158,7 @@ public class GT_TileEntity_THTR extends GT_MetaTileEntity_EnhancedMultiBlockBase
                 .addOutputHatch("Any bottom layer casing", 1)
                 .addEnergyHatch("Any bottom layer casing", 1)
                 .addMaintenanceHatch("Any bottom layer casing", 1)
-                .toolTipFinisher("Bartworks");
+                .toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 
@@ -235,7 +236,7 @@ public class GT_TileEntity_THTR extends GT_MetaTileEntity_EnhancedMultiBlockBase
 
     @Override
     public boolean checkRecipe(ItemStack controllerStack) {
-        
+
         if(this.empty)
         {
             if(this.HeliumSupply > 0 || this.fuelsupply > 0){
@@ -305,7 +306,7 @@ public class GT_TileEntity_THTR extends GT_MetaTileEntity_EnhancedMultiBlockBase
                 }
             }
         }
-        
+
         if(drainedamount > 0)
             addOutput(FluidRegistry.getFluidStack("ic2hotcoolant", drainedamount));
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_Windmill.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_Windmill.java
@@ -64,6 +64,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static gregtech.api.enums.GT_Values.V;
@@ -139,7 +140,7 @@ public class GT_TileEntity_Windmill extends GT_MetaTileEntity_EnhancedMultiBlock
             addOtherStructurePart("Dispenser", "Any Hardened Clay block").
             addOtherStructurePart("0-1 Wooden door", "Any Hardened Clay block").
             addStructureHint("Primitive Kinetic Shaftbox", 1).
-            toolTipFinisher("Bartworks");
+            toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -54,6 +54,7 @@ import net.minecraftforge.fluids.FluidStack;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.getMultiOutput;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.handleParallelRecipe;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
@@ -163,7 +164,7 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
                 .addStructureInfo("Recovery amount scales with Muffler Hatch tier")
                 .addOutputHatch("Platline fluids, Any bottom layer casing")
                 .addStructureHint("This Mega Multiblock is too big to have its structure hologram displayed fully.")
-                .toolTipFinisher(BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get());
+                .toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -49,6 +49,7 @@ import net.minecraftforge.fluids.FluidStack;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.getMultiOutput;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.handleParallelRecipe;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
@@ -91,7 +92,7 @@ public class GT_TileEntity_MegaChemicalReactor extends GT_TileEntity_MegaMultiBl
                 .addInputBus("Hint block ",1)
                 .addOutputBus("Hint block ",1)
                 .addOutputHatch("Hint block ",1)
-                .toolTipFinisher("Bartworks");
+                .toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
@@ -52,6 +52,7 @@ import net.minecraftforge.fluids.FluidStack;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.getMultiOutput;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.handleParallelRecipe;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
@@ -228,7 +229,7 @@ public class GT_TileEntity_MegaDistillTower extends GT_TileEntity_MegaMultiBlock
                 .addOutputHatch("2-11x Output Hatches (One per Output Layer except bottom layer)")
                 .addStructureInfo("An \"Output Layer\" consists of 5 layers!")
                 .addStructureHint("This Mega Multiblock is too big to have its structure hologram displayed fully.")
-                .toolTipFinisher(BW_Tooltip_Reference.ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS.get());
+                .toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaOilCracker.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaOilCracker.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.getMultiOutput;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.handleParallelRecipe;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
@@ -129,7 +130,7 @@ public class GT_TileEntity_MegaOilCracker extends GT_TileEntity_MegaMultiBlockBa
                 .addInputHatch("Hint block",2,3)
                 .addOutputHatch("Hint block",2,3)
                 .addInputHatch("Steam/Hydrogen ONLY, Hint block",4)
-                .toolTipFinisher("Bartworks");
+                .toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
@@ -45,6 +45,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import java.util.ArrayList;
 
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.getMultiOutput;
 import static com.github.bartimaeusnek.bartworks.util.RecipeFinderForParallel.handleParallelRecipe;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
@@ -116,7 +117,7 @@ public class GT_TileEntity_MegaVacuumFreezer extends GT_TileEntity_MegaMultiBloc
             addOutputHatch("Any casing", 1).
             addInputBus("Any casing", 1).
             addOutputBus("Any casing", 1).
-            toolTipFinisher("Bartworks");
+            toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_MetaGeneratedBlock_Item.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_MetaGeneratedBlock_Item.java
@@ -77,7 +77,11 @@ public class BW_MetaGeneratedBlock_Item extends BW_ItemBlocks {
         }
         Werkstoff werkstoff = Werkstoff.werkstoffHashMap.get((short) aStack.getItemDamage());
         if(werkstoff != null) {
-            aList.add(werkstoff.getLocalizedToolTip());
+            String tooltip = werkstoff.getLocalizedToolTip();
+            if (!tooltip.isEmpty()) {
+                aList.add(werkstoff.getLocalizedToolTip());
+            }
+
             String owner = werkstoff.getOwner();
             if (owner != null) {
                 aList.add(BW_Tooltip_Reference.ADDED_VIA_BARTWORKS.apply(owner));

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_MetaGenerated_Items.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_MetaGenerated_Items.java
@@ -135,9 +135,18 @@ public class BW_MetaGenerated_Items extends GT_MetaGenerated_Item implements IRa
             aList.add(GT_LanguageManager.getTranslation("metaitem.01.tooltip.nqgen"));
 
         Werkstoff werkstoff = werkstoffHashMap.get((short) this.getDamage(aStack));
-        String owner = werkstoff.getOwner();
-        if (owner != null) {
-            aList.add(BW_Tooltip_Reference.ADDED_VIA_BARTWORKS.apply(owner));
+        if (werkstoff != null) {
+            String tooltip = werkstoff.getLocalizedToolTip();
+            if (!tooltip.isEmpty()) {
+                aList.add(werkstoff.getLocalizedToolTip());
+            }
+
+            String owner = werkstoff.getOwner();
+            if (owner != null) {
+                aList.add(BW_Tooltip_Reference.ADDED_VIA_BARTWORKS.apply(owner));
+            } else {
+                aList.add(BW_Tooltip_Reference.ADDED_BY_BARTWORKS.get());
+            }
         } else {
             aList.add(BW_Tooltip_Reference.ADDED_BY_BARTWORKS.get());
         }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/GT_Enhancement/BWGTMetaItems.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/GT_Enhancement/BWGTMetaItems.java
@@ -119,8 +119,9 @@ public class BWGTMetaItems extends BW_MetaGenerated_Items {
     protected void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
         Materials material = getMaterial(aStack);
         if (material != null) {
-            if (material.getToolTip() != null) {
-                aList.add(material.getToolTip());
+            String tooltip = material.getToolTip();
+            if (tooltip != null && !tooltip.isEmpty()) {
+                aList.add(tooltip);
             }
         }
         aList.add(BW_Tooltip_Reference.ADDED_BY_BARTWORKS.get());

--- a/src/main/java/com/github/bartimaeusnek/bartworks/util/BW_Tooltip_Reference.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/util/BW_Tooltip_Reference.java
@@ -33,9 +33,14 @@ public class BW_Tooltip_Reference {
     public static final String TT_NO_RESET = BLUE + "Tec" + DARK_BLUE + "Tech";
     public static final String BW = BW_NO_RESET + GRAY;
     public static final String TT = TT_NO_RESET + GRAY;
+
     public static final Supplier<String> ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS = () -> StatCollector.translateToLocal("tooltip.bw.1.name") + " " + BW;
     public static final Supplier<String> ADDED_BY_BARTWORKS = () -> StatCollector.translateToLocal("tooltip.bw.0.name") + " " + BW;
     public static final Function<String, String> ADDED_VIA_BARTWORKS = owner -> String.format(StatCollector.translateToLocal("tooltip.bw.via.name"), owner);
+    public static final String MULTIBLOCK_ADDED_BY_BARTWORKS = BW;
+    public static final Function<String, String> MULTIBLOCK_ADDED_VIA_BARTWORKS = owner -> String.format(StatCollector.translateToLocal("tooltip.bw.mb_via.name"), owner);
+    public static final String MULTIBLOCK_ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS = MULTIBLOCK_ADDED_VIA_BARTWORKS.apply(GREEN + "bartimaeusnek");
+
     public static final String ADV_STR_CHECK = "Uses an advanced "+ TT +" structure check, due to "+ BW;
     public static final String TT_BLUEPRINT = "To see the structure, use a "+ TT + " Blueprint on the Controller!";
 

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -62,6 +62,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static bloodasp.galacticgreg.registry.GalacticGregRegistry.getModContainers;
+import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTWORKS;
 import static gregtech.api.enums.GT_Values.VN;
 
 @SuppressWarnings("ALL")
@@ -192,7 +193,7 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
                 .addInputBus("Mining Pipes or Ores, optional, any base casing")
                 .addInputHatch("Optional noble gas, any base casing")
                 .addOutputBus("Any base casing")
-                .toolTipFinisher("Gregtech");
+                .toolTipFinisher(MULTIBLOCK_ADDED_BY_BARTWORKS);
         return tt;
     }
 

--- a/src/main/resources/assets/bartworks/lang/en_US.lang
+++ b/src/main/resources/assets/bartworks/lang/en_US.lang
@@ -86,6 +86,7 @@ tooltip.bw.kg.0.name=kg
 tooltip.bw.kg.1.name=kgs
 tooltip.bw.empty.name=Empty
 tooltip.bw.via.name=Added by %s§7 via §2BartWorks
+tooltip.bw.mb_via.name=%s§7 via §2BartWorks
 
 tooltip.teslastaff.0.name=No warranty!
 tooltip.labmodule.0.name=A Module used to change the BioLab's working Mode


### PR DESCRIPTION
- Fix duplicated "Added by"
- Use colored string "BartWorks"
- Don't add tooltip if formula is empty (GT material items)
- Add formula tooltips to dusts, cells, etc. (Werkstoff materials)