### PR TITLE
forbid electrolyz fluid when it has dust form

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/CellLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/CellLoader.java
@@ -54,6 +54,9 @@ public class CellLoader implements IWerkstoffRunnable {
         if (!werkstoff.hasItemType(cell))
             return;
 
+        if (werkstoff.hasItemType(dust))
+            return;
+
         if (werkstoff.getStats().isElektrolysis() || werkstoff.getStats().isCentrifuge()) {
             List<FluidStack> flOutputs = new ArrayList<>();
             List<ItemStack> stOutputs = new ArrayList<>();


### PR DESCRIPTION
it means this fluid isn't a standard fluid, so fluid electrolyz rule doesn't apply to it(like calcium chloride）