### PR TITLE
EIG: Unlock Primordial crop

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -203,7 +203,6 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             addInfo("Process time: 5 sec").
             addInfo("All crops are accelerated by x32 times").
             addInfo("1 Fertilizer per 1 crop +10%").
-            addInfo("Cannot process primordial").
             addInfo(BW_Tooltip_Reference.TT_BLUEPRINT).
             addSeparator().
             beginStructureBlock(5, 4, 5, false).
@@ -693,8 +692,6 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse extends GT_MetaTileEntity
             if(!ItemList.IC2_Crop_Seeds.isStackEqual(input, true, true))
                 return;
             CropCard cc = Crops.instance.getCropCard(input);
-            if(cc.tier() > 15) // dont process primordial
-                return;
             this.input.stackSize = 1;
             NBTTagCompound nbt = input.getTagCompound();
             byte gr = nbt.getByte("growth");


### PR DESCRIPTION
It was blacklisted only because the replication was blocked.
But now after that change: https://github.com/GTNewHorizons/Crops-plus-plus/pull/42 ,
there is no longer a reason to block it