### PR TITLE
Fix oredicted circuit parts preventing CAL recipe generation

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/CircuitGeneration/CircuitImprintLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/CircuitGeneration/CircuitImprintLoader.java
@@ -27,6 +27,7 @@ import com.github.bartimaeusnek.bartworks.common.configs.ConfigHandler;
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import com.github.bartimaeusnek.bartworks.util.BWRecipes;
 import com.github.bartimaeusnek.bartworks.util.BW_Util;
+import com.github.bartimaeusnek.bartworks.util.Pair;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -38,7 +39,10 @@ import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
@@ -203,11 +207,30 @@ public class CircuitImprintLoader {
     private static void replaceCircuits(
             BiMap<ItemList, Short> inversed, GT_Recipe original, ItemStack[] in, int index) {
         for (ItemList il : inversed.keySet()) {
-            if (GT_Utility.areStacksEqual(il.get(1), original.mInputs[index])) {
+            if (GT_Utility.areStacksEqual(il.get(1), replaceCircuitParts(original.mInputs[index]))) {
                 in[index] =
                         BW_Meta_Items.getNEWCIRCUITS().getStack(inversed.get(il), original.mInputs[index].stackSize);
             }
         }
+    }
+
+    private static final List<Pair<ItemStack, ItemStack>> circuitPartsToReplace =
+            Collections.unmodifiableList(Arrays.asList(
+                    new Pair<>(ItemList.Circuit_Parts_Resistor.get(1), ItemList.Circuit_Parts_ResistorSMD.get(1)),
+                    new Pair<>(ItemList.Circuit_Parts_Diode.get(1), ItemList.Circuit_Parts_DiodeSMD.get(1)),
+                    new Pair<>(ItemList.Circuit_Parts_Transistor.get(1), ItemList.Circuit_Parts_TransistorSMD.get(1)),
+                    new Pair<>(ItemList.Circuit_Parts_Capacitor.get(1), ItemList.Circuit_Parts_CapacitorSMD.get(1)),
+                    new Pair<>(ItemList.Circuit_Parts_Coil.get(1), ItemList.Circuit_Parts_InductorSMD.get(1))));
+
+    private static ItemStack replaceCircuitParts(ItemStack stack) {
+        for (Pair<ItemStack, ItemStack> pair : circuitPartsToReplace) {
+            if (GT_Utility.areStacksEqual(pair.getKey(), stack)) {
+                ItemStack newStack = pair.getValue();
+                newStack.stackSize = stack.stackSize;
+                return newStack;
+            }
+        }
+        return stack;
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/CircuitGeneration/CircuitPartLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/CircuitGeneration/CircuitPartLoader.java
@@ -61,12 +61,7 @@ public class CircuitPartLoader implements Runnable {
                     || single == Circuit_Integrated
                     || single == Circuit_Parts_PetriDish
                     || single == Circuit_Parts_Vacuum_Tube
-                    || single == Circuit_Integrated_Good
-                    || single == Circuit_Parts_Capacitor
-                    || single == Circuit_Parts_Diode
-                    || single == Circuit_Parts_Resistor
-                    || single == Circuit_Parts_Transistor
-                    || single == Circuit_Parts_Coil) {
+                    || single == Circuit_Integrated_Good) {
 
                 CircuitImprintLoader.blacklistSet.add(single.get(1));
             }


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11651

With the addition of oredicted diode (https://github.com/GTNewHorizons/GT5-Unofficial/pull/1040), circuit recipes using primitive diode and SMD diode are unified to recipes using primitive diode. Since primitive parts were forbidden for generating CAL recipes, circuit recipes accepting primitive parts, not only diode but also other components, were not generating CAL recipes.
Many of circuit recipes were affected by this issue, but they were not found until today because ASMD or SoC recipes were still available I guess.