### PR TITLE
Werkstoff Fluid Solidifier Recipe Generation 

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
@@ -832,6 +832,15 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
          * Auto add MetalWorking(crafting components) Recipe 10000
          */
         public byte extraRecipes;
+        
+        /*
+         * Here so that new recipes don't fuck with existing functionality
+         * Auto add Crafting Metal Solidifier recipes 1
+         * Auto add Meta Crafting Metal Solidifier recipes 10
+         * Auto add Multiple Ingot Metal Solidifier recipes 100 (Unused)
+         */
+        public byte extraRecipes2;
+        
         public short mixCircuit = -1;
 
         public Werkstoff.GenerationFeatures setBlacklist(OrePrefixes p) {
@@ -885,7 +894,34 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
         public boolean hasChemicalRecipes() {
             return (this.extraRecipes & 1) != 0;
         }
-
+        
+        public Werkstoff.GenerationFeatures addMetalCraftingSolidifierRecipes() {
+        	this.extraRecipes2 = (byte) (this.extraRecipes2 | 1);
+        	return this;
+        }  
+        
+        public boolean hasMetalCraftingSolidifierRecipes() {
+        	return (this.extraRecipes2 & 1) != 0;
+        }
+        
+        public Werkstoff.GenerationFeatures addMetaSolidifierRecipes() {
+        	this.extraRecipes2 = (byte) (this.extraRecipes2 | 10);
+        	return this;
+        }
+        
+        public boolean hasMetaSolidifierRecipes() {
+        	return (this.extraRecipes2 & 10) != 0;
+        }
+        
+        public Werkstoff.GenerationFeatures addMultipleMetalSolidifierRecipes() {
+        	this.extraRecipes2 = (byte) (this.extraRecipes2 | 100);
+        	return this;
+        }
+        
+        public boolean hasMultipleMetalSolidifierRecipes() {
+        	return (this.extraRecipes2 & 100) != 0;
+        }
+        
         public Werkstoff.GenerationFeatures addMixerRecipes() {
             this.extraRecipes = (byte) (this.extraRecipes | 10);
             return this;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/Werkstoff.java
@@ -832,7 +832,7 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
          * Auto add MetalWorking(crafting components) Recipe 10000
          */
         public byte extraRecipes;
-        
+
         /*
          * Here so that new recipes don't fuck with existing functionality
          * Auto add Crafting Metal Solidifier recipes 1
@@ -840,7 +840,7 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
          * Auto add Multiple Ingot Metal Solidifier recipes 100 (Unused)
          */
         public byte extraRecipes2;
-        
+
         public short mixCircuit = -1;
 
         public Werkstoff.GenerationFeatures setBlacklist(OrePrefixes p) {
@@ -894,34 +894,34 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
         public boolean hasChemicalRecipes() {
             return (this.extraRecipes & 1) != 0;
         }
-        
+
         public Werkstoff.GenerationFeatures addMetalCraftingSolidifierRecipes() {
-        	this.extraRecipes2 = (byte) (this.extraRecipes2 | 1);
-        	return this;
-        }  
-        
+            this.extraRecipes2 = (byte) (this.extraRecipes2 | 1);
+            return this;
+        }
+
         public boolean hasMetalCraftingSolidifierRecipes() {
-        	return (this.extraRecipes2 & 1) != 0;
+            return (this.extraRecipes2 & 1) != 0;
         }
-        
+
         public Werkstoff.GenerationFeatures addMetaSolidifierRecipes() {
-        	this.extraRecipes2 = (byte) (this.extraRecipes2 | 10);
-        	return this;
+            this.extraRecipes2 = (byte) (this.extraRecipes2 | 10);
+            return this;
         }
-        
+
         public boolean hasMetaSolidifierRecipes() {
-        	return (this.extraRecipes2 & 10) != 0;
+            return (this.extraRecipes2 & 10) != 0;
         }
-        
+
         public Werkstoff.GenerationFeatures addMultipleMetalSolidifierRecipes() {
-        	this.extraRecipes2 = (byte) (this.extraRecipes2 | 100);
-        	return this;
+            this.extraRecipes2 = (byte) (this.extraRecipes2 | 100);
+            return this;
         }
-        
+
         public boolean hasMultipleMetalSolidifierRecipes() {
-        	return (this.extraRecipes2 & 100) != 0;
+            return (this.extraRecipes2 & 100) != 0;
         }
-        
+
         public Werkstoff.GenerationFeatures addMixerRecipes() {
             this.extraRecipes = (byte) (this.extraRecipes | 10);
             return this;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
@@ -1356,9 +1356,7 @@ public class WerkstoffLoader {
                     .addMixerRecipes()
                     .addSimpleMetalWorkingItems()
                     .addCraftingMetalWorkingItems()
-                    .addMultipleIngotMetalWorkingItems()
-                   
-                    ,
+                    .addMultipleIngotMetalWorkingItems(),
             90,
             TextureSet.SET_METALLIC,
             new Pair<>(WerkstoffLoader.Ruthenium, 2),

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
@@ -1356,7 +1356,9 @@ public class WerkstoffLoader {
                     .addMixerRecipes()
                     .addSimpleMetalWorkingItems()
                     .addCraftingMetalWorkingItems()
-                    .addMultipleIngotMetalWorkingItems(),
+                    .addMultipleIngotMetalWorkingItems()
+                   
+                    ,
             90,
             TextureSet.SET_METALLIC,
             new Pair<>(WerkstoffLoader.Ruthenium, 2),

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/CraftingMaterialLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/CraftingMaterialLoader.java
@@ -162,36 +162,36 @@ public class CraftingMaterialLoader implements IWerkstoffRunnable {
 
             // molten -> metal
             if (werkstoff.hasItemType(WerkstoffLoader.cellMolten)) {
-                
-            	/* !! No more hardcoded gear, etc. recipe gen, now must go through GenerationFeatures() !!
-            	
-            	GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Gear.get(0L), werkstoff.getMolten(576), werkstoff.get(gearGt), 128, 8);
-                GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Gear_Small.get(0L),
-                        werkstoff.getMolten(144),
-                        werkstoff.get(gearGtSmall),
-                        16,
-                        8);
-                if (WerkstoffLoader.ringMold != null)
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                            WerkstoffLoader.ringMold.get(0L),
-                            werkstoff.getMolten(36),
-                            werkstoff.get(ring),
-                            100,
-                            4 * tVoltageMultiplier);
-                if (WerkstoffLoader.boltMold != null)
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                            WerkstoffLoader.boltMold.get(0L),
-                            werkstoff.getMolten(18),
-                            werkstoff.get(bolt),
-                            50,
-                            2 * tVoltageMultiplier);
 
-                if (WerkstoffLoader.rotorMold != null)
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                            WerkstoffLoader.rotorMold.get(0L), werkstoff.getMolten(612), werkstoff.get(rotor), 100, 60);
-                */
+                /* !! No more hardcoded gear, etc. recipe gen, now must go through GenerationFeatures() !!
+
+                GT_Values.RA.addFluidSolidifierRecipe(
+                           ItemList.Shape_Mold_Gear.get(0L), werkstoff.getMolten(576), werkstoff.get(gearGt), 128, 8);
+                   GT_Values.RA.addFluidSolidifierRecipe(
+                           ItemList.Shape_Mold_Gear_Small.get(0L),
+                           werkstoff.getMolten(144),
+                           werkstoff.get(gearGtSmall),
+                           16,
+                           8);
+                   if (WerkstoffLoader.ringMold != null)
+                       GT_Values.RA.addFluidSolidifierRecipe(
+                               WerkstoffLoader.ringMold.get(0L),
+                               werkstoff.getMolten(36),
+                               werkstoff.get(ring),
+                               100,
+                               4 * tVoltageMultiplier);
+                   if (WerkstoffLoader.boltMold != null)
+                       GT_Values.RA.addFluidSolidifierRecipe(
+                               WerkstoffLoader.boltMold.get(0L),
+                               werkstoff.getMolten(18),
+                               werkstoff.get(bolt),
+                               50,
+                               2 * tVoltageMultiplier);
+
+                   if (WerkstoffLoader.rotorMold != null)
+                       GT_Values.RA.addFluidSolidifierRecipe(
+                               WerkstoffLoader.rotorMold.get(0L), werkstoff.getMolten(612), werkstoff.get(rotor), 100, 60);
+                   */
             }
 
             GT_Values.RA.addPulveriserRecipe(

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/CraftingMaterialLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/CraftingMaterialLoader.java
@@ -162,7 +162,10 @@ public class CraftingMaterialLoader implements IWerkstoffRunnable {
 
             // molten -> metal
             if (werkstoff.hasItemType(WerkstoffLoader.cellMolten)) {
-                GT_Values.RA.addFluidSolidifierRecipe(
+                
+            	/* !! No more hardcoded gear, etc. recipe gen, now must go through GenerationFeatures() !!
+            	
+            	GT_Values.RA.addFluidSolidifierRecipe(
                         ItemList.Shape_Mold_Gear.get(0L), werkstoff.getMolten(576), werkstoff.get(gearGt), 128, 8);
                 GT_Values.RA.addFluidSolidifierRecipe(
                         ItemList.Shape_Mold_Gear_Small.get(0L),
@@ -188,6 +191,7 @@ public class CraftingMaterialLoader implements IWerkstoffRunnable {
                 if (WerkstoffLoader.rotorMold != null)
                     GT_Values.RA.addFluidSolidifierRecipe(
                             WerkstoffLoader.rotorMold.get(0L), werkstoff.getMolten(612), werkstoff.get(rotor), 100, 60);
+                */
             }
 
             GT_Values.RA.addPulveriserRecipe(

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/MoltenCellLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/MoltenCellLoader.java
@@ -129,6 +129,94 @@ public class MoltenCellLoader implements IWerkstoffRunnable {
                     0,
                     (int) ((double) werkstoff.getStats().getMass() / 2D),
                     werkstoff.getStats().getMass() > 128 ? 64 : 30);
+            
+            
+            
+            
+        }
+        
+        if (werkstoff.getGenerationFeatures().hasMetalCraftingSolidifierRecipes()) {
+        	
+        	if (!werkstoff.hasItemType(plate)) return;
+        		
+        	
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Rod_Long.get(0), 
+        			werkstoff.getMolten(144), 
+        			werkstoff.get(stickLong), 
+        			(int) Math.max(werkstoff.getStats().getMass(), 1L),
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        	
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Rod.get(0), 
+        			werkstoff.getMolten(72), 
+        			werkstoff.get(stick), 
+        			(int) Math.max(werkstoff.getStats().getMass() / 2, 1L),
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        	
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Plate.get(0), 
+        			werkstoff.getMolten(144), 
+        			werkstoff.get(plate), 
+        			(int) Math.max(werkstoff.getStats().getMass(), 1L),
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        			
+        }
+        
+        if (werkstoff.getGenerationFeatures().hasMetaSolidifierRecipes()) {
+        	if (!werkstoff.hasItemType(screw)) return;
+        	
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Screw.get(0), 
+        			werkstoff.getMolten(18), 
+        			werkstoff.get(screw), 
+        			(int) Math.max(werkstoff.getStats().getMass() / 8, 1L),
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        	
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Gear.get(0), 
+        			werkstoff.getMolten(576), 
+        			werkstoff.get(gearGt), 
+        			(int) Math.max(werkstoff.getStats().getMass() / 4, 1L),
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        	
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Gear_Small.get(0), 
+        			werkstoff.getMolten(144), 
+        			werkstoff.get(gearGtSmall), 
+        			(int) Math.max(werkstoff.getStats().getMass(), 1L), 
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        	
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Bolt.get(0), 
+        			werkstoff.getMolten(18), 
+        			werkstoff.get(bolt), 
+        			(int) Math.max(werkstoff.getStats().getMass() / 8, 1L), 
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        	
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Ring.get(0), 
+        			werkstoff.getMolten(36), 
+        			werkstoff.get(ring), 
+        			(int) Math.max(werkstoff.getStats().getMass() / 4, 1L), 
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        	
+        	// No Spring Molds
+        	
+        	if (WerkstoffLoader.rotorMold == null) return;
+        	GT_Values.RA.addFluidSolidifierRecipe(
+        			ItemList.Shape_Mold_Rotor.get(0), 
+        			werkstoff.getMolten(612), 
+        			werkstoff.get(rotor), 
+        			(int) Math.max(werkstoff.getStats().getMass() * 4.25, 1L), 
+        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
+        		
+        			
+        }
+        
+        if (werkstoff.getGenerationFeatures().hasMultipleMetalSolidifierRecipes()) {
+        	if (!werkstoff.hasItemType(plateDouble)) return;
+        	// No multiple plate molds
         }
 
         // Tank "Recipe"

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/MoltenCellLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/werkstoff_loaders/recipe/MoltenCellLoader.java
@@ -129,94 +129,86 @@ public class MoltenCellLoader implements IWerkstoffRunnable {
                     0,
                     (int) ((double) werkstoff.getStats().getMass() / 2D),
                     werkstoff.getStats().getMass() > 128 ? 64 : 30);
-            
-            
-            
-            
         }
-        
+
         if (werkstoff.getGenerationFeatures().hasMetalCraftingSolidifierRecipes()) {
-        	
-        	if (!werkstoff.hasItemType(plate)) return;
-        		
-        	
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Rod_Long.get(0), 
-        			werkstoff.getMolten(144), 
-        			werkstoff.get(stickLong), 
-        			(int) Math.max(werkstoff.getStats().getMass(), 1L),
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        	
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Rod.get(0), 
-        			werkstoff.getMolten(72), 
-        			werkstoff.get(stick), 
-        			(int) Math.max(werkstoff.getStats().getMass() / 2, 1L),
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        	
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Plate.get(0), 
-        			werkstoff.getMolten(144), 
-        			werkstoff.get(plate), 
-        			(int) Math.max(werkstoff.getStats().getMass(), 1L),
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        			
+
+            if (!werkstoff.hasItemType(plate)) return;
+
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Rod_Long.get(0),
+                    werkstoff.getMolten(144),
+                    werkstoff.get(stickLong),
+                    (int) Math.max(werkstoff.getStats().getMass(), 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
+
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Rod.get(0),
+                    werkstoff.getMolten(72),
+                    werkstoff.get(stick),
+                    (int) Math.max(werkstoff.getStats().getMass() / 2, 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
+
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Plate.get(0),
+                    werkstoff.getMolten(144),
+                    werkstoff.get(plate),
+                    (int) Math.max(werkstoff.getStats().getMass(), 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
         }
-        
+
         if (werkstoff.getGenerationFeatures().hasMetaSolidifierRecipes()) {
-        	if (!werkstoff.hasItemType(screw)) return;
-        	
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Screw.get(0), 
-        			werkstoff.getMolten(18), 
-        			werkstoff.get(screw), 
-        			(int) Math.max(werkstoff.getStats().getMass() / 8, 1L),
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        	
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Gear.get(0), 
-        			werkstoff.getMolten(576), 
-        			werkstoff.get(gearGt), 
-        			(int) Math.max(werkstoff.getStats().getMass() / 4, 1L),
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        	
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Gear_Small.get(0), 
-        			werkstoff.getMolten(144), 
-        			werkstoff.get(gearGtSmall), 
-        			(int) Math.max(werkstoff.getStats().getMass(), 1L), 
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        	
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Bolt.get(0), 
-        			werkstoff.getMolten(18), 
-        			werkstoff.get(bolt), 
-        			(int) Math.max(werkstoff.getStats().getMass() / 8, 1L), 
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        	
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Ring.get(0), 
-        			werkstoff.getMolten(36), 
-        			werkstoff.get(ring), 
-        			(int) Math.max(werkstoff.getStats().getMass() / 4, 1L), 
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        	
-        	// No Spring Molds
-        	
-        	if (WerkstoffLoader.rotorMold == null) return;
-        	GT_Values.RA.addFluidSolidifierRecipe(
-        			ItemList.Shape_Mold_Rotor.get(0), 
-        			werkstoff.getMolten(612), 
-        			werkstoff.get(rotor), 
-        			(int) Math.max(werkstoff.getStats().getMass() * 4.25, 1L), 
-        			werkstoff.getStats().getMass() > 128 ? 64 : 30);
-        		
-        			
+            if (!werkstoff.hasItemType(screw)) return;
+
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Screw.get(0),
+                    werkstoff.getMolten(18),
+                    werkstoff.get(screw),
+                    (int) Math.max(werkstoff.getStats().getMass() / 8, 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
+
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Gear.get(0),
+                    werkstoff.getMolten(576),
+                    werkstoff.get(gearGt),
+                    (int) Math.max(werkstoff.getStats().getMass() / 4, 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
+
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Gear_Small.get(0),
+                    werkstoff.getMolten(144),
+                    werkstoff.get(gearGtSmall),
+                    (int) Math.max(werkstoff.getStats().getMass(), 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
+
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Bolt.get(0),
+                    werkstoff.getMolten(18),
+                    werkstoff.get(bolt),
+                    (int) Math.max(werkstoff.getStats().getMass() / 8, 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
+
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Ring.get(0),
+                    werkstoff.getMolten(36),
+                    werkstoff.get(ring),
+                    (int) Math.max(werkstoff.getStats().getMass() / 4, 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
+
+            // No Spring Molds
+
+            if (WerkstoffLoader.rotorMold == null) return;
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Rotor.get(0),
+                    werkstoff.getMolten(612),
+                    werkstoff.get(rotor),
+                    (int) Math.max(werkstoff.getStats().getMass() * 4.25, 1L),
+                    werkstoff.getStats().getMass() > 128 ? 64 : 30);
         }
-        
+
         if (werkstoff.getGenerationFeatures().hasMultipleMetalSolidifierRecipes()) {
-        	if (!werkstoff.hasItemType(plateDouble)) return;
-        	// No multiple plate molds
+            if (!werkstoff.hasItemType(plateDouble)) return;
+            // No multiple plate molds
         }
 
         // Tank "Recipe"


### PR DESCRIPTION
- Remove always-on gear, rotor, bolt fluid recipes to allow for greater control
- Add separate generation options for two main "tiers" of Werkstoff materials, where "addMetalCraftingSolidifierRecipes" adds rod, plate recipes and "addMetaSolidifierRecipes" adds the recipes for gears, screws, bolts, rings