### PR TITLE
No Humidity Mode for the EIG

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -19,6 +19,7 @@ package com.github.bartimaeusnek.bartworks.common.tileentities.multis;
 
 import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_VIA_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
+import static gregtech.api.enums.GT_Values.AuthorKuba;
 import static gregtech.api.enums.Textures.BlockIcons.*;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -84,7 +84,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
     private boolean isIC2Mode = false;
     private byte glasTier = 0;
     private int waterusage = 0;
-    private static boolean isNoHumidity = false;
+    private boolean isNoHumidity = false;
     private static final int CASING_INDEX = 49;
     private static final String STRUCTURE_PIECE_MAIN = "main";
     private static final Item forestryfertilizer = GameRegistry.findItem("Forestry", "fertilizerCompound");
@@ -516,7 +516,8 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
             if (!mStorage.get(i).isValid) continue;
             StringBuilder a = new StringBuilder(
                     "Slot " + i + ": " + EnumChatFormatting.GREEN + "x" + this.mStorage.get(i).input.stackSize + " "
-                            + this.mStorage.get(i).input.getDisplayName());
+                            + this.mStorage.get(i).input.getDisplayName() + " | Humidity: "
+                            + (this.mStorage.get(i).noHumidity ? 0 : 12));
             if (this.isIC2Mode) {
                 a.append(" : ");
                 for (Map.Entry<String, Double> entry :
@@ -580,7 +581,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                     g.addAll(this.getBaseMetaTileEntity().getWorld(), input);
                     if (input.stackSize == 0) return true;
                 }
-        GreenHouseSlot h = new GreenHouseSlot(this, input, true, isIC2Mode);
+        GreenHouseSlot h = new GreenHouseSlot(this, input, true, isIC2Mode, isNoHumidity);
         if (h.isValid) {
             mStorage.add(h);
             return true;
@@ -596,6 +597,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
         List<ItemStack> drops;
         boolean isValid;
         boolean isIC2Crop;
+        boolean noHumidity;
         int growthticks;
         List<List<ItemStack>> generations;
 
@@ -633,6 +635,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                                 generations.get(i).get(j).writeToNBT(new NBTTagCompound()));
                 }
                 aNBT.setInteger("growthticks", growthticks);
+                aNBT.setBoolean("noHumidity", noHumidity);
             }
             return aNBT;
         }
@@ -717,13 +720,18 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
         }
 
         public GreenHouseSlot(
-                GT_TileEntity_ExtremeIndustrialGreenhouse tileEntity, ItemStack input, boolean autocraft, boolean IC2) {
+                GT_TileEntity_ExtremeIndustrialGreenhouse tileEntity,
+                ItemStack input,
+                boolean autocraft,
+                boolean IC2,
+                boolean noHumidity) {
             super(null, 3, 3);
             World world = tileEntity.getBaseMetaTileEntity().getWorld();
             this.input = input.copy();
             this.isValid = false;
+            this.noHumidity = noHumidity;
             if (IC2) {
-                GreenHouseSlotIC2(tileEntity, world, input);
+                GreenHouseSlotIC2(tileEntity, world, input, noHumidity);
                 return;
             }
             Item i = input.getItem();
@@ -765,7 +773,10 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
         }
 
         public void GreenHouseSlotIC2(
-                GT_TileEntity_ExtremeIndustrialGreenhouse tileEntity, World world, ItemStack input) {
+                GT_TileEntity_ExtremeIndustrialGreenhouse tileEntity,
+                World world,
+                ItemStack input,
+                boolean noHumidity) {
             if (!ItemList.IC2_Crop_Seeds.isStackEqual(input, true, true)) return;
             CropCard cc = Crops.instance.getCropCard(input);
             this.input.stackSize = 1;
@@ -847,7 +858,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                 rn = new Random();
 
                 // CHECK GROWTH SPEED
-                te.humidity = (byte) (isNoHumidity == true ? 0 : 12); // humidity with full water storage or 0 humidity
+                te.humidity = (byte) (noHumidity ? 0 : 12); // humidity with full water storage or 0 humidity
                 te.airQuality = 6; // air quality when sky is seen
                 te.nutrients = 8; // netrients with full nutrient storage
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -25,6 +25,7 @@ import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
 import com.github.bartimaeusnek.bartworks.API.BorosilicateGlass;
 import com.github.bartimaeusnek.bartworks.API.LoaderReference;
+import com.github.bartimaeusnek.bartworks.client.renderer.BW_CropVisualizer;
 import com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference;
 import com.github.bartimaeusnek.bartworks.util.ChatColorHelper;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentLimits;
@@ -53,6 +54,7 @@ import ic2.core.crop.TileEntityCrop;
 import java.util.*;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockStem;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -845,7 +847,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                 rn = new Random();
 
                 // CHECK GROWTH SPEED
-                te.humidity = (byte) (isNoHumidity == true ? 0 : 12); // humidity with full water storage
+                te.humidity = (byte) (isNoHumidity == true ? 0 : 12); // humidity with full water storage or 0 humidity
                 te.airQuality = 6; // air quality when sky is seen
                 te.nutrients = 8; // netrients with full nutrient storage
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -19,7 +19,6 @@ package com.github.bartimaeusnek.bartworks.common.tileentities.multis;
 
 import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_VIA_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
-import static gregtech.api.enums.GT_Values.AuthorKuba;
 import static gregtech.api.enums.Textures.BlockIcons.*;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
@@ -644,6 +643,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
             super(null, 3, 3);
             isIC2Crop = aNBT.getBoolean("isIC2Crop");
             isValid = aNBT.getBoolean("isValid");
+            noHumidity = aNBT.getBoolean("noHumidity");
             input = ItemStack.loadItemStackFromNBT(aNBT.getCompoundTag("input"));
             if (!isIC2Crop) {
                 crop = Block.getBlockById(aNBT.getInteger("crop"));

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -25,7 +25,6 @@ import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
 import com.github.bartimaeusnek.bartworks.API.BorosilicateGlass;
 import com.github.bartimaeusnek.bartworks.API.LoaderReference;
-import com.github.bartimaeusnek.bartworks.client.renderer.BW_CropVisualizer;
 import com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference;
 import com.github.bartimaeusnek.bartworks.util.ChatColorHelper;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentLimits;
@@ -54,7 +53,6 @@ import ic2.core.crop.TileEntityCrop;
 import java.util.*;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockStem;
-import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -84,6 +82,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
     private boolean isIC2Mode = false;
     private byte glasTier = 0;
     private int waterusage = 0;
+    private static boolean isNoHumidity = false;
     private static final int CASING_INDEX = 49;
     private static final String STRUCTURE_PIECE_MAIN = "main";
     private static final Item forestryfertilizer = GameRegistry.findItem("Forestry", "fertilizerCompound");
@@ -183,6 +182,14 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
     }
 
     @Override
+    public boolean onWireCutterRightClick(
+            byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        isNoHumidity = !isNoHumidity;
+        GT_Utility.sendChatToPlayer(aPlayer, "Give incoming crops no humidity " + isNoHumidity);
+        return true;
+    }
+
+    @Override
     public IMetaTileEntity newMetaEntity(IGregTechTileEntity iGregTechTileEntity) {
         return new GT_TileEntity_ExtremeIndustrialGreenhouse(this.mName);
     }
@@ -269,6 +276,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
         aNBT.setByte("glasTier", glasTier);
         aNBT.setInteger("setupphase", setupphase);
         aNBT.setBoolean("isIC2Mode", isIC2Mode);
+        aNBT.setBoolean("isNoHumidity", isNoHumidity);
         aNBT.setInteger("mStorageSize", mStorage.size());
         for (int i = 0; i < mStorage.size(); i++)
             aNBT.setTag("mStorage." + i, mStorage.get(i).toNBTTagCompound());
@@ -280,6 +288,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
         glasTier = aNBT.getByte("glasTier");
         setupphase = aNBT.getInteger("setupphase");
         isIC2Mode = aNBT.getBoolean("isIC2Mode");
+        isNoHumidity = aNBT.getBoolean("isNoHumidity");
         for (int i = 0; i < aNBT.getInteger("mStorageSize"); i++)
             mStorage.add(new GreenHouseSlot(aNBT.getCompoundTag("mStorage." + i)));
     }
@@ -836,7 +845,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                 rn = new Random();
 
                 // CHECK GROWTH SPEED
-                te.humidity = 12; // humidity with full water storage
+                te.humidity = (byte) (isNoHumidity == true ? 0 : 12); // humidity with full water storage
                 te.airQuality = 6; // air quality when sky is seen
                 te.nutrients = 8; // netrients with full nutrient storage
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -19,7 +19,6 @@ package com.github.bartimaeusnek.bartworks.common.tileentities.multis;
 
 import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_VIA_BARTWORKS;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
-import static gregtech.api.enums.GT_Values.AuthorKuba;
 import static gregtech.api.enums.Textures.BlockIcons.*;
 import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
@@ -219,6 +218,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                 .addInfo("Grow your crops like a chad !")
                 .addInfo("Use screwdriver to enable/change/disable setup mode")
                 .addInfo("Use screwdriver while sneaking to enable/disable IC2 mode")
+                .addInfo("Use wire cutters to give incoming IC2 crops 0 humidity")
                 .addInfo("Uses 1000L of water per crop per operation")
                 .addInfo("You can insert fertilizer each operation to get more drops (max +400%)")
                 .addInfo("-------------------- SETUP   MODE --------------------")
@@ -516,10 +516,9 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
             if (!mStorage.get(i).isValid) continue;
             StringBuilder a = new StringBuilder(
                     "Slot " + i + ": " + EnumChatFormatting.GREEN + "x" + this.mStorage.get(i).input.stackSize + " "
-                            + this.mStorage.get(i).input.getDisplayName() + " | Humidity: "
-                            + (this.mStorage.get(i).noHumidity ? 0 : 12));
+                            + this.mStorage.get(i).input.getDisplayName());
             if (this.isIC2Mode) {
-                a.append(" : ");
+                a.append(" | Humidity: " + (this.mStorage.get(i).noHumidity ? 0 : 12) + " : ");
                 for (Map.Entry<String, Double> entry :
                         mStorage.get(i).dropprogress.entrySet())
                     a.append((int) (entry.getValue() * 100d)).append("% ");
@@ -644,7 +643,6 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
             super(null, 3, 3);
             isIC2Crop = aNBT.getBoolean("isIC2Crop");
             isValid = aNBT.getBoolean("isValid");
-            noHumidity = aNBT.getBoolean("noHumidity");
             input = ItemStack.loadItemStackFromNBT(aNBT.getCompoundTag("input"));
             if (!isIC2Crop) {
                 crop = Block.getBlockById(aNBT.getInteger("crop"));
@@ -666,6 +664,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                                 .add(ItemStack.loadItemStackFromNBT(aNBT.getCompoundTag("generation." + i + "." + j)));
                 }
                 growthticks = aNBT.getInteger("growthticks");
+                noHumidity = aNBT.getBoolean("noHumidity");
                 rn = new Random();
             }
         }


### PR DESCRIPTION
Designed only for Salty Root since the base environmental stats in the EIG mess with the optimal growth stat for Salty Root in the EIG. With the current stats, optimal growth is 11 or 12:
![image](https://user-images.githubusercontent.com/43712386/199867178-e472cf36-9821-4787-84cb-4e0fd3a54a91.png)

Growth 31 is comically terrible in comparison:
![image](https://user-images.githubusercontent.com/43712386/199867227-9f8af5cb-5f7c-4661-b191-2e62d2d34be9.png)
This is confusing for someone trying to min/max their crops for the EIG.

With 0 humidity, growth rate is always increasing with growth up to 31.
![image](https://user-images.githubusercontent.com/43712386/199867414-fe266a13-41db-4f6f-96c7-53def58b6d22.png)

The way it works is that it sets the environmental stats for crops that are added **after** the mode is turned on (e.g. If you turn on no humidity mode, put in 3 crops, turn off no humidity mode, and put in 1 crop, the first 3 crops will use 0 humidity, while the last crop will use the standard 12 humidity).