### PR TITLE
prevent incorrect fluid from being forced into liquid air hatch

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.205:dev")
+    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.207:dev")
     compile("com.github.GTNewHorizons:StructureLib:1.2.0-beta.2:dev")
     compile("com.github.GTNewHorizons:TecTech:5.0.67:dev")
     compile("com.github.GTNewHorizons:NotEnoughItems:2.3.20-GTNH:dev")

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
@@ -22,12 +22,17 @@
 
 package com.github.bartimaeusnek.bartworks.common.tileentities.tiered;
 
+import com.gtnewhorizons.modularui.common.internal.network.NetworkUtils;
 import gregtech.api.enums.Materials;
+import gregtech.api.interfaces.IFluidAccess;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Input;
 import gregtech.api.util.GT_Utility;
+import gregtech.common.gui.modularui.widget.FluidDisplaySlotWidget;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Hatch_Input {
@@ -55,5 +60,10 @@ public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Ha
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_CompressedFluidHatch(
                 this.mName, this.mTier, this.mDescriptionArray, this.mTextures);
+    }
+
+    @Override
+    protected FluidDisplaySlotWidget createDrainableFluidSlot() {
+        return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.LiquidAir.mFluid);
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
@@ -22,17 +22,13 @@
 
 package com.github.bartimaeusnek.bartworks.common.tileentities.tiered;
 
-import com.gtnewhorizons.modularui.common.internal.network.NetworkUtils;
 import gregtech.api.enums.Materials;
-import gregtech.api.interfaces.IFluidAccess;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Input;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.gui.modularui.widget.FluidDisplaySlotWidget;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Hatch_Input {


### PR DESCRIPTION
Prompted by discussion in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12224. A proper fix to uncraftable issue need to be devised, instead of coercing some fluid into liquid air hatch.