### PR TITLE
Optical Circuit recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1673027205
+//version: 1674409054
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -144,6 +144,7 @@ propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
 propertyDefaultIfUnset("curseForgeRelations", "")
+propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
@@ -411,7 +412,9 @@ shadowJar {
         attributes(getManifestAttributes())
     }
 
-    minimize()  // This will only allow shading for actually used classes
+    if (minimizeShadowedDependencies.toBoolean()) {
+        minimize()  // This will only allow shading for actually used classes
+    }
     configurations = [
         project.configurations.shadowImplementation,
         project.configurations.shadowCompile
@@ -554,7 +557,9 @@ task shadowDevJar(type: ShadowJar) {
         attributes(getManifestAttributes())
     }
 
-    minimize()  // This will only allow shading for actually used classes
+    if (minimizeShadowedDependencies.toBoolean()) {
+        minimize()  // This will only allow shading for actually used classes
+    }
     configurations = [
         project.configurations.shadowImplementation,
         project.configurations.shadowCompile

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.211:dev")
+    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.232:dev")
     compile("com.github.GTNewHorizons:StructureLib:1.2.0-beta.2:dev")
     compile("com.github.GTNewHorizons:TecTech:5.0.67:dev")
     compile("com.github.GTNewHorizons:NotEnoughItems:2.3.20-GTNH:dev")

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -611,7 +611,7 @@ public class StaticRecipeChangeLoaders {
                             "Electric Implosion Compressor",
                             (String) null,
                             "gregtech:textures/gui/basicmachines/Default",
-                            1,
+                            2,
                             2,
                             0,
                             0,
@@ -654,6 +654,24 @@ public class StaticRecipeChangeLoaders {
                     100 * 20,
                     128_000_000,
                     1); // aSpecialVaue has no meaning here.
+        }
+
+        if (Loader.isModLoaded("universalsingularities")) {
+
+            // Raw Exposed Optical Chip
+            eicMap.addRecipe(
+                    false,
+                    new ItemStack[] {
+                        ItemList.Circuit_Silicon_Wafer7.get(1L),
+                        GT_ModHandler.getModItem("universalsingularities", "universal.general.singularity", 1L, 20)
+                    },
+                    new ItemStack[] {ItemList.Circuit_Chip_Optical.get(16L)},
+                    null,
+                    new FluidStack[] {GT_Values.NF},
+                    new FluidStack[] {GT_Values.NF},
+                    10 * 20,
+                    31_457_280,
+                    1);
         }
 
         eicMap.addRecipe(

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -669,8 +669,8 @@ public class StaticRecipeChangeLoaders {
                     null,
                     new FluidStack[] {GT_Values.NF},
                     new FluidStack[] {GT_Values.NF},
-                    10 * 20,
-                    31_457_280,
+                    5 * 20,
+                    125_829_120,
                     1);
         }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/CircuitGeneration/CircuitImprintLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/CircuitGeneration/CircuitImprintLoader.java
@@ -107,8 +107,13 @@ public class CircuitImprintLoader {
                     ? FluidRegistry.getFluid("molten.indalloy140")
                     : FluidRegistry.getFluid("molten.solderingalloy");
 
+            Fluid solderUEV = FluidRegistry.getFluid("molten.mutatedlivingsolder") != null
+                    ? FluidRegistry.getFluid("molten.mutatedlivingsolder")
+                    : FluidRegistry.getFluid("molten.solderingalloy");
+
             if (circuitRecipe.mFluidInputs[0].isFluidEqual(Materials.SolderingAlloy.getMolten(0))
-                    || circuitRecipe.mFluidInputs[0].isFluidEqual(new FluidStack(solderIndalloy, 0))) {
+                    || circuitRecipe.mFluidInputs[0].isFluidEqual(new FluidStack(solderIndalloy, 0))
+                    || circuitRecipe.mFluidInputs[0].isFluidEqual(new FluidStack(solderUEV, 0))) {
                 GT_Recipe newRecipe = CircuitImprintLoader.reBuildRecipe(circuitRecipe);
                 if (newRecipe != null)
                     BWRecipes.instance

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/CircuitGeneration/CircuitPartLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/CircuitGeneration/CircuitPartLoader.java
@@ -155,5 +155,10 @@ public class CircuitPartLoader implements Runnable {
             Circuit_Parts_TransistorXSMD,
             Circuit_Parts_CapacitorXSMD,
             Circuit_Parts_InductorASMD,
-            Circuit_Parts_InductorXSMD));
+            Circuit_Parts_InductorXSMD,
+            Circuit_Chip_Optical,
+            Circuit_Board_Optical,
+            Optically_Perfected_CPU,
+            Optical_Cpu_Containment_Housing,
+            Optically_Compatible_Memory));
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
@@ -189,7 +189,7 @@ public class AdditionalRecipes {
                     },
                     BioItemList.mBioLabParts[4],
                     new int[] {7500, 10000},
-                    new FluidStack[] {new FluidStack(dnaFluid[0].getFluid(), 9000)},
+                    new FluidStack[] {new FluidStack(dnaFluid[0].getFluid(), 8000)},
                     null,
                     500,
                     BW_Util.getMachineVoltageFromTier(6),

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
@@ -46,6 +46,7 @@ import gregtech.api.util.GT_Utility;
 import gregtech.common.items.behaviors.Behaviour_DataOrb;
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.Objects;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -152,7 +153,7 @@ public class AdditionalRecipes {
                         BioData.getBioDataFromNBTTag(stack.getTagCompound().getCompoundTag("DNA"));
                 BioData Plasmid =
                         BioData.getBioDataFromNBTTag(stack.getTagCompound().getCompoundTag("Plasmid"));
-                if (DNA.getName() != Plasmid.getName()) {
+                if (!Objects.equals(DNA.getName(), Plasmid.getName())) {
                     sBiolab.addFakeRecipe(
                             true,
                             new ItemStack[] {
@@ -162,7 +163,7 @@ public class AdditionalRecipes {
                             },
                             new ItemStack[] {stack, ItemList.Cell_Empty.get(1L)},
                             BioItemList.mBioLabParts[3],
-                            new int[] {10000, 10000},
+                            new int[] {Plasmid.getChance(), 10000},
                             new FluidStack[] {FluidRegistry.getFluidStack("ic2distilledwater", 1000)},
                             null,
                             500,


### PR DESCRIPTION
adds some wraps for optical circuit parts, expands the input slots for the EIC and allows the use of mutated living solder in the circuit assembly line
![image](https://user-images.githubusercontent.com/93287602/213924911-7e45232f-8507-4903-a74e-2e4cdf28cdbe.png)

also adds a recipe for raw exposed optical chips
![image](https://user-images.githubusercontent.com/93287602/213924904-45b04bc7-e306-4718-9c22-275cfbd5e1ed.png)
