### PR TITLE
Make reflection Java 12+ compatible

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,12 +1,13 @@
 // Add your dependencies here
 
 dependencies {
+    compile("com.github.GTNewHorizons:GTNHLib:0.0.10:dev")
     compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.211:dev")
     compile("com.github.GTNewHorizons:StructureLib:1.2.0-beta.2:dev")
     compile("com.github.GTNewHorizons:TecTech:5.0.67:dev")
     compile("com.github.GTNewHorizons:NotEnoughItems:2.3.20-GTNH:dev")
     compile("com.github.GTNewHorizons:TinkersConstruct:1.9.11-GTNH:dev")
-    compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.6:dev")
+    compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.7:dev")
     compile("com.github.GTNewHorizons:CodeChickenCore:1.1.7:dev")
     compile("com.github.GTNewHorizons:Galacticraft:3.0.63-GTNH:dev")
     compile("com.github.GTNewHorizons:ModularUI:1.0.38:dev")
@@ -44,6 +45,6 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:ProjectRed:4.7.9-GTNH:dev") {
         transitive = false
     }
-    runtime("com.github.GTNewHorizons:Yamcl:0.5.84:dev")
-    runtime("com.github.GTNewHorizons:ironchest:6.0.71:dev") //needed for Galacticraft
+    runtimeOnly("com.github.GTNewHorizons:Yamcl:0.5.84:dev")
+    runtimeOnly("com.github.GTNewHorizons:ironchest:6.0.71:dev") //needed for Galacticraft
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,6 @@
 // Add your dependencies here
 
 dependencies {
-    compile("com.github.GTNewHorizons:GTNHLib:0.0.10:dev")
     compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.211:dev")
     compile("com.github.GTNewHorizons:StructureLib:1.2.0-beta.2:dev")
     compile("com.github.GTNewHorizons:TecTech:5.0.67:dev")

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -36,6 +36,7 @@ import com.github.bartimaeusnek.bartworks.util.StreamUtils;
 import com.github.bartimaeusnek.bartworks.util.log.DebugLog;
 import com.github.bartimaeusnek.crossmod.BartWorksCrossmod;
 import com.google.common.collect.ArrayListMultimap;
+import com.gtnewhorizon.gtnhlib.reflect.Fields;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -49,7 +50,6 @@ import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gregtech.api.util.GT_Utility;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.stream.Collectors;
 import net.minecraft.init.Blocks;
@@ -59,7 +59,6 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
 
 public class StaticRecipeChangeLoaders {
 
@@ -698,15 +697,11 @@ public class StaticRecipeChangeLoaders {
     }
 
     public static void patchEBFMapForCircuitUnification() {
-        Field mUsualInputCount = FieldUtils.getField(GT_Recipe.GT_Recipe_Map.class, "mUsualInputCount", true);
-        mUsualInputCount.setAccessible(true);
-
         try {
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(mUsualInputCount, mUsualInputCount.getModifiers() & ~Modifier.FINAL);
-            mUsualInputCount.setInt(GT_Recipe.GT_Recipe_Map.sBlastRecipes, 3);
-        } catch (IllegalAccessException | NoSuchFieldException e) {
+            Fields.ofClass(GT_Recipe_Map.class)
+                    .getIntField(Fields.LookupType.PUBLIC, "mUsualInputCount")
+                    .setValue(GT_Recipe.GT_Recipe_Map.sBlastRecipes, 3);
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -36,7 +36,6 @@ import com.github.bartimaeusnek.bartworks.util.StreamUtils;
 import com.github.bartimaeusnek.bartworks.util.log.DebugLog;
 import com.github.bartimaeusnek.crossmod.BartWorksCrossmod;
 import com.google.common.collect.ArrayListMultimap;
-import com.gtnewhorizon.gtnhlib.reflect.Fields;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -694,23 +693,6 @@ public class StaticRecipeChangeLoaders {
                 || GT_Utility.areStacksEqual(input, GT_ModHandler.getIC2Item("industrialTnt", 1L))
                 || GT_Utility.areStacksEqual(input, GT_ModHandler.getIC2Item("dynamite", 1L))
                 || GT_Utility.areStacksEqual(input, ItemList.Block_Powderbarrel.get(1L)));
-    }
-
-    public static void patchEBFMapForCircuitUnification() {
-        try {
-            Fields.ofClass(GT_Recipe_Map.class)
-                    .getIntField(Fields.LookupType.PUBLIC, "mUsualInputCount")
-                    .setValue(GT_Recipe.GT_Recipe_Map.sBlastRecipes, 3);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    public static void synchroniseCircuitUseMulti() {
-        GT_Recipe.GT_Recipe_Map[] gt_recipe_maps = {
-            GT_Recipe.GT_Recipe_Map.sMultiblockChemicalRecipes, GT_Recipe.GT_Recipe_Map.sBlastRecipes
-        };
-        getRecipesByCircuitID(gt_recipe_maps).forEach(StaticRecipeChangeLoaders::transformCircuitRecipes);
     }
 
     private static int getBlastLogic(GT_Recipe recipe) {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/GT_Enhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/GT_Enhancement/PlatinumSludgeOverHaul.java
@@ -48,7 +48,6 @@ import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.blocks.GT_Block_Ores_Abstract;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.*;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
@@ -956,32 +955,6 @@ public class PlatinumSludgeOverHaul {
         Field in = CachedReflectionUtils.getDeclaredField(recipe.getClass(), inputItemName);
         if (in == null) in = CachedReflectionUtils.getField(recipe.getClass(), inputItemName);
         if (in == null) return;
-
-        // directly copied from the apache commons collection, cause GTNH had problems with that particular function for
-        // some reason?
-        // this part here is NOT MIT LICENSED BUT LICSENSED UNDER THE Apache License, Version 2.0!
-        try {
-            if (Modifier.isFinal(in.getModifiers())) {
-                // Do all JREs implement Field with a private ivar called "modifiers"?
-                Field modifiersField = Field.class.getDeclaredField("modifiers");
-                boolean doForceAccess = !modifiersField.isAccessible();
-                if (doForceAccess) {
-                    modifiersField.setAccessible(true);
-                }
-                try {
-                    modifiersField.setInt(in, in.getModifiers() & ~Modifier.FINAL);
-                } finally {
-                    if (doForceAccess) {
-                        modifiersField.setAccessible(false);
-                    }
-                }
-            }
-        } catch (NoSuchFieldException ignored) {
-            // The field class contains always a modifiers field
-        } catch (IllegalAccessException ignored) {
-            // The modifiers field is made accessible
-        }
-        // END OF APACHE COMMONS COLLECTION COPY
 
         Object input;
         try {


### PR DESCRIPTION
In PlatinumSludgeOverhaul there is no need to make the field non-final because it is only read from.