### PR TITLE
Adds asmds, xsmds, indalloy, and living solder to Magneto Resonatic Circuits consistent with the other circuits

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
@@ -395,16 +395,16 @@ public class AdditionalRecipes {
                 50,
                 120);
 
-		// Magneto Resonatic Circuits
-		
-		Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
-                    ? FluidRegistry.getFluid("molten.indalloy140")
-                    : FluidRegistry.getFluid("molten.solderingalloy");
+        // Magneto Resonatic Circuits
+
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
+                ? FluidRegistry.getFluid("molten.indalloy140")
+                : FluidRegistry.getFluid("molten.solderingalloy");
 
         Fluid solderUEV = FluidRegistry.getFluid("molten.mutatedlivingsolder") != null
-                    ? FluidRegistry.getFluid("molten.mutatedlivingsolder")
-                    : FluidRegistry.getFluid("molten.solderingalloy");
-		// ULV
+                ? FluidRegistry.getFluid("molten.mutatedlivingsolder")
+                : FluidRegistry.getFluid("molten.solderingalloy");
+        // ULV
         GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
                 new BWRecipes.DynamicGTRecipe(
                         false,
@@ -420,7 +420,7 @@ public class AdditionalRecipes {
                         750,
                         BW_Util.getMachineVoltageFromTier(1),
                         CLEANROOM));
-		// LV-EV
+        // LV-EV
         for (int i = 1; i <= 4; i++) {
             GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
                     new BWRecipes.DynamicGTRecipe(
@@ -440,8 +440,8 @@ public class AdditionalRecipes {
                             BW_Util.getMachineVoltageFromTier((i + 1)),
                             CLEANROOM));
         }
-		// IV-LuV
-		for (int i = 5; i <= 6; i++) {
+        // IV-LuV
+        for (int i = 5; i <= 6; i++) {
             GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
                     new BWRecipes.DynamicGTRecipe(
                             false,
@@ -460,43 +460,43 @@ public class AdditionalRecipes {
                             BW_Util.getMachineVoltageFromTier((i + 1)),
                             CLEANROOM));
         }
-		// ZPM
-		GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
-                    new BWRecipes.DynamicGTRecipe(
-                            false,
-                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(3),
-                                    WerkstoffLoader.MagnetoResonaticDust.get(gemExquisite, (1)),
-                                    BW_Meta_Items.getNEWCIRCUITS().getStack(7 + 3),
-                                    ItemList.Circuit_Parts_DiodeASMD.get((7 + 6) * 4),
-                                    ItemList.Circuit_Parts_CapacitorASMD.get((7 + 6) * 4),
-                                    ItemList.Circuit_Parts_TransistorASMD.get((7 + 6) * 4) },
-                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(7 + 4) },
-                            null,
-                            null,
-                            new FluidStack[] { new FluidStack(solderIndalloy, (7 + 1) * 36) },
-                            null,
-                            (7 + 1) * 1500,
-                            BW_Util.getMachineVoltageFromTier(7 + 1),
-                            CLEANROOM));
-		// UV
-		GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
-                    new BWRecipes.DynamicGTRecipe(
-                            false,
-                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(3),
-                                    WerkstoffLoader.MagnetoResonaticDust.get(gemExquisite, (1)),
-                                    BW_Meta_Items.getNEWCIRCUITS().getStack(8 + 3),
-                                    ItemList.Circuit_Parts_DiodeASMD.get((8 + 6) * 4),
-                                    ItemList.Circuit_Parts_CapacitorASMD.get((8 + 6) * 4),
-                                    ItemList.Circuit_Parts_TransistorASMD.get((8 + 6) * 4) },
-                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(8 + 4) },
-                            null,
-                            null,
-                            new FluidStack[] { new FluidStack(solderUEV, (8 + 1) * 36) },
-                            null,
-                            (8 + 1) * 1500,
-                            BW_Util.getMachineVoltageFromTier(8 + 1),
-                            CLEANROOM));
-		// UHV-UEV
+        // ZPM
+        GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
+                new BWRecipes.DynamicGTRecipe(
+                        false,
+                        new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(3),
+                                WerkstoffLoader.MagnetoResonaticDust.get(gemExquisite, (1)),
+                                BW_Meta_Items.getNEWCIRCUITS().getStack(7 + 3),
+                                ItemList.Circuit_Parts_DiodeASMD.get((7 + 6) * 4),
+                                ItemList.Circuit_Parts_CapacitorASMD.get((7 + 6) * 4),
+                                ItemList.Circuit_Parts_TransistorASMD.get((7 + 6) * 4) },
+                        new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(7 + 4) },
+                        null,
+                        null,
+                        new FluidStack[] { new FluidStack(solderIndalloy, (7 + 1) * 36) },
+                        null,
+                        (7 + 1) * 1500,
+                        BW_Util.getMachineVoltageFromTier(7 + 1),
+                        CLEANROOM));
+        // UV
+        GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
+                new BWRecipes.DynamicGTRecipe(
+                        false,
+                        new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(3),
+                                WerkstoffLoader.MagnetoResonaticDust.get(gemExquisite, (1)),
+                                BW_Meta_Items.getNEWCIRCUITS().getStack(8 + 3),
+                                ItemList.Circuit_Parts_DiodeASMD.get((8 + 6) * 4),
+                                ItemList.Circuit_Parts_CapacitorASMD.get((8 + 6) * 4),
+                                ItemList.Circuit_Parts_TransistorASMD.get((8 + 6) * 4) },
+                        new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(8 + 4) },
+                        null,
+                        null,
+                        new FluidStack[] { new FluidStack(solderUEV, (8 + 1) * 36) },
+                        null,
+                        (8 + 1) * 1500,
+                        BW_Util.getMachineVoltageFromTier(8 + 1),
+                        CLEANROOM));
+        // UHV-UEV
         for (int i = 9; i <= 10; i++) {
             GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
                     new BWRecipes.DynamicGTRecipe(

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
@@ -395,6 +395,16 @@ public class AdditionalRecipes {
                 50,
                 120);
 
+		// Magneto Resonatic Circuits
+		
+		Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
+                    ? FluidRegistry.getFluid("molten.indalloy140")
+                    : FluidRegistry.getFluid("molten.solderingalloy");
+
+        Fluid solderUEV = FluidRegistry.getFluid("molten.mutatedlivingsolder") != null
+                    ? FluidRegistry.getFluid("molten.mutatedlivingsolder")
+                    : FluidRegistry.getFluid("molten.solderingalloy");
+		// ULV
         GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
                 new BWRecipes.DynamicGTRecipe(
                         false,
@@ -410,7 +420,8 @@ public class AdditionalRecipes {
                         750,
                         BW_Util.getMachineVoltageFromTier(1),
                         CLEANROOM));
-        for (int i = 1; i <= 6; i++) {
+		// LV-EV
+        for (int i = 1; i <= 4; i++) {
             GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
                     new BWRecipes.DynamicGTRecipe(
                             false,
@@ -429,20 +440,77 @@ public class AdditionalRecipes {
                             BW_Util.getMachineVoltageFromTier((i + 1)),
                             CLEANROOM));
         }
-        for (int i = 7; i <= 10; i++) {
+		// IV-LuV
+		for (int i = 5; i <= 6; i++) {
+            GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
+                    new BWRecipes.DynamicGTRecipe(
+                            false,
+                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(3),
+                                    WerkstoffLoader.MagnetoResonaticDust.get(gem),
+                                    BW_Meta_Items.getNEWCIRCUITS().getStack(i + 3),
+                                    ItemList.Circuit_Parts_DiodeASMD.get((i + 1) * 4),
+                                    ItemList.Circuit_Parts_CapacitorASMD.get((i + 1) * 4),
+                                    ItemList.Circuit_Parts_TransistorASMD.get((i + 1) * 4) },
+                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(i + 4) },
+                            null,
+                            null,
+                            new FluidStack[] { new FluidStack(solderIndalloy, (i + 1) * 36) },
+                            null,
+                            (i + 1) * 750,
+                            BW_Util.getMachineVoltageFromTier((i + 1)),
+                            CLEANROOM));
+        }
+		// ZPM
+		GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
+                    new BWRecipes.DynamicGTRecipe(
+                            false,
+                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(3),
+                                    WerkstoffLoader.MagnetoResonaticDust.get(gemExquisite, (1)),
+                                    BW_Meta_Items.getNEWCIRCUITS().getStack(7 + 3),
+                                    ItemList.Circuit_Parts_DiodeASMD.get((7 + 6) * 4),
+                                    ItemList.Circuit_Parts_CapacitorASMD.get((7 + 6) * 4),
+                                    ItemList.Circuit_Parts_TransistorASMD.get((7 + 6) * 4) },
+                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(7 + 4) },
+                            null,
+                            null,
+                            new FluidStack[] { new FluidStack(solderIndalloy, (7 + 1) * 36) },
+                            null,
+                            (7 + 1) * 1500,
+                            BW_Util.getMachineVoltageFromTier(7 + 1),
+                            CLEANROOM));
+		// UV
+		GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
+                    new BWRecipes.DynamicGTRecipe(
+                            false,
+                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(3),
+                                    WerkstoffLoader.MagnetoResonaticDust.get(gemExquisite, (1)),
+                                    BW_Meta_Items.getNEWCIRCUITS().getStack(8 + 3),
+                                    ItemList.Circuit_Parts_DiodeASMD.get((8 + 6) * 4),
+                                    ItemList.Circuit_Parts_CapacitorASMD.get((8 + 6) * 4),
+                                    ItemList.Circuit_Parts_TransistorASMD.get((8 + 6) * 4) },
+                            new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(8 + 4) },
+                            null,
+                            null,
+                            new FluidStack[] { new FluidStack(solderUEV, (8 + 1) * 36) },
+                            null,
+                            (8 + 1) * 1500,
+                            BW_Util.getMachineVoltageFromTier(8 + 1),
+                            CLEANROOM));
+		// UHV-UEV
+        for (int i = 9; i <= 10; i++) {
             GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes.add(
                     new BWRecipes.DynamicGTRecipe(
                             false,
                             new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(3),
                                     WerkstoffLoader.MagnetoResonaticDust.get(gemExquisite, (1)),
                                     BW_Meta_Items.getNEWCIRCUITS().getStack(i + 3),
-                                    ItemList.Circuit_Parts_DiodeSMD.get((i + 6) * 4),
-                                    ItemList.Circuit_Parts_CapacitorSMD.get((i + 6) * 4),
-                                    ItemList.Circuit_Parts_TransistorSMD.get((i + 6) * 4) },
+                                    ItemList.Circuit_Parts_DiodeXSMD.get((i + 6) * 4),
+                                    ItemList.Circuit_Parts_CapacitorXSMD.get((i + 6) * 4),
+                                    ItemList.Circuit_Parts_TransistorXSMD.get((i + 6) * 4) },
                             new ItemStack[] { BW_Meta_Items.getNEWCIRCUITS().getStack(i + 4) },
                             null,
                             null,
-                            new FluidStack[] { Materials.SolderingAlloy.getMolten((i + 1) * 144) },
+                            new FluidStack[] { new FluidStack(solderUEV, (i + 1) * 36) },
                             null,
                             (i + 1) * 1500,
                             BW_Util.getMachineVoltageFromTier(i + 1),


### PR DESCRIPTION
For example (in usernm texturepack):

![image](https://user-images.githubusercontent.com/40274384/217108683-446ae02f-5b3f-4a3f-8285-e4f08ed1fd03.png)

(asmds, indalloy)

![image](https://user-images.githubusercontent.com/40274384/217108562-b036f4a1-81b1-4ac0-9317-d26fa115ec4a.png)

(xsmds, living solder)

Addresses 1) and 2) of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12450