### PR TITLE
Adjust the balance of the EIG

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -252,16 +252,16 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                 .addInfo("All crops are grown at the end of the operation")
                 .addInfo("Will automatically craft seeds if they are not dropped")
                 .addInfo("Uses 1000L of CO2 per crop per operation for +10% bonus production")
-                .addInfo("2 Fertilizer per 1 crop +200% bonus production")
+                .addInfo("1 Fertilizer per 1 crop +200% bonus production")
                 .addInfo("-------------------- IC2    CROPS --------------------")
                 .addInfo("Minimal tier: " + tierString(6)).addInfo("Need " + tierString(6) + " glass tier")
                 .addInfo("Starting with 8 slots").addInfo("Every slot gives 1 crop")
                 .addInfo("Every tier past " + tierString(6) + ", slots are multiplied by 4")
                 .addInfo("Process time: 5 sec").addInfo("All crops are accelerated by x32 times")
-                .addInfo("Uses 1000L of CO2 per crop per operation for +20% bonus growth speed")
-                .addInfo("2 Fertilizer per 1 crop +20% bonus growth speed").addInfo(BW_Tooltip_Reference.TT_BLUEPRINT)
-                .addSeparator().beginStructureBlock(5, 6, 5, false).addController("Front bottom center")
-                .addCasingInfo("Clean Stainless Steel Casings", 70)
+                .addInfo("Uses 1000L of CO2 per crop slot for an additional +20% growth speed")
+                .addInfo("Uses 1 to 40 Fertilizer per crop slot for an additional 10% to 400% growth speed")
+                .addInfo(BW_Tooltip_Reference.TT_BLUEPRINT).addSeparator().beginStructureBlock(5, 6, 5, false)
+                .addController("Front bottom center").addCasingInfo("Clean Stainless Steel Casings", 70)
                 .addOtherStructurePart("Borosilicate Glass", "Hollow two middle layers")
                 .addStructureInfo("The glass tier limits the Energy Input tier")
                 .addStructureInfo("The dirt is from RandomThings, must be tilled")
@@ -463,7 +463,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
         waterusage *= 1000;
 
         final FluidInputDrainResults waterDrainResults = getFluidInputsOfSize(waterusage, FluidRegistry.WATER);
-        if (!waterDrainResults.canDrainFullAmount) return false;
+        if (!waterDrainResults.canDrainFullAmount && !debug) return false;
         drainAmountFromInputs(waterusage, waterDrainResults.fluidInputs);
 
         // carbon dioxide
@@ -491,7 +491,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
 
         int boost = 0;
         int maxboost = 0;
-        for (GreenHouseSlot s : mStorage) maxboost += s.input.stackSize * 2;
+        for (GreenHouseSlot s : mStorage) maxboost += s.input.stackSize * (isIC2Mode ? 40 : 2);
 
         ArrayList<ItemStack> inputs = getStoredInputs();
         for (ItemStack i : inputs) {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -510,8 +510,8 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
             this.mMaxProgresstime = 100;
             final double progressTime = this.mMaxProgresstime * 32d;
             final double bonusTimeTotal = progressTime
-                    + progressTime * (0.2 * ((double) carbonDioxideToDrain / (double) carbonDioxideOptimalAmount))
-                    + progressTime * (0.2 * ((double) boost / (double) maxboost));
+                    + progressTime * (0.2d * ((double) carbonDioxideToDrain / (double) carbonDioxideOptimalAmount))
+                    + progressTime * (4d * ((double) boost / (double) maxboost));
 
             List<ItemStack> outputs = new ArrayList<>();
             for (int i = 0; i < Math.min(mMaxSlots, mStorage.size()); i++)

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -519,8 +519,8 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
             this.mOutputItems = outputs.toArray(new ItemStack[0]);
         } else {
             this.mMaxProgresstime = Math.max(20, 100 / (tier - 3)); // Min 1 s
-            double multiplier = 1.d + (((double) boost / (double) maxboost) * 4d);
-            multiplier += (((double) carbonDioxideToDrain / (double) carbonDioxideOptimalAmount));
+            final double multiplier = 1.d + (4d * ((double) boost / (double) maxboost))
+                    + (0.2d * ((double) carbonDioxideToDrain / (double) carbonDioxideOptimalAmount));
             List<ItemStack> outputs = new ArrayList<>();
             for (int i = 0; i < Math.min(mMaxSlots, mStorage.size()); i++) {
                 for (ItemStack drop : mStorage.get(i).getDrops()) {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ExtremeIndustrialGreenhouse.java
@@ -256,7 +256,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
                 .addInfo("-------------------- IC2    CROPS --------------------")
                 .addInfo("Minimal tier: " + tierString(6)).addInfo("Need " + tierString(6) + " glass tier")
                 .addInfo("Starting with 8 slots").addInfo("Every slot gives 1 crop")
-                .addInfo("Every tier past " + tierString(6) + ", slots are multiplied by 4")
+                .addInfo("Every tier past " + tierString(6) + ", slots are multiplied by 2")
                 .addInfo("Process time: 5 sec").addInfo("All crops are accelerated by x32 times")
                 .addInfo("Uses 1000L of CO2 per crop slot for an additional +20% growth speed")
                 .addInfo("Uses 1 to 40 Fertilizer per crop slot for an additional 10% to 400% growth speed")
@@ -355,7 +355,7 @@ public class GT_TileEntity_ExtremeIndustrialGreenhouse
         long v = this.getMaxInputVoltage();
         int tier = GT_Utility.getTier(v);
         if (tier < (isIC2Mode ? 6 : 4)) mMaxSlots = 0;
-        else if (isIC2Mode) mMaxSlots = 8 << (2 * (tier - 6));
+        else if (isIC2Mode) mMaxSlots = 8 << (tier - 6);
         else mMaxSlots = 1 << (tier - 4);
     }
 


### PR DESCRIPTION
* Added more details to the tooltip to be more clear on what fertilizer & CO2 does

* Change the starting slots of IC2 mode to 8. mostly to match the plots in the EIG

* Change the usage of fertilizer to match what the tooltip say per operation

* Change the calculation of the multiplyer for IC2 mode to be bonus to growth time

* Added a way to boost growing speed in IC2 mode by adding CO2 gas match to the number of crop slots

* Added a way to boost the production in normal mode with CO2 gas