### PR TITLE
Remove silliness with the muffler hatches on the MBF

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -114,12 +114,12 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
 
         raw[0] = new String[15];
         String topCasing = "ttttttttttttttt";
-        String mufflerLine = "tmmmmmmmmmmmmmt";
+        String middleTopCasing = "tttttttmttttttt";
         raw[0][0] = topCasing;
-        for (int i = 1; i < 14; i++) {
-            raw[0][i] = mufflerLine;
+        for (int i = 1; i < 15; i++) {
+            raw[0][i] = topCasing;
         }
-        raw[0][14] = topCasing;
+        raw[0][7] = middleTopCasing;
 
         raw[1] = new String[15];
         String allGlass = "ggggggggggggggg";

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -269,15 +269,6 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
     }
 
     @Override
-    public boolean addMufflerToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
-        if (super.addMufflerToMachineList(aTileEntity, aBaseCasingIndex)) {
-            if (mufflerTier == -1) mufflerTier = this.mMufflerHatches.get(this.mMufflerHatches.size() - 1).mTier;
-            return mufflerTier == this.mMufflerHatches.get(this.mMufflerHatches.size() - 1).mTier;
-        }
-        return false;
-    }
-
-    @Override
     public int getPollutionPerTick(ItemStack aStack) {
         return this.polPtick;
     }


### PR DESCRIPTION
This PR aims to remove all the muffler hatches except the middle one on the MBF.

By the sheer amount of mufflers, you get quite some lag just because of their existence. To give you an idea, @Sphyix on delta has 17 MBF, for an UEV player, that isn't surprising. With his 17 MBFs, in idle mode,they generate 2.9ms.

It is known since a long while now that code wise, the pollution exhaust can keep up with only one muffler hatch.

This PR will unform all the MBFs tho, but that's in the players' interest.