### PR TITLE
optimization bacterial vat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1678003329
+//version: 1679040806
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -695,13 +695,13 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.1.35'
+    def lwjgl3ifyVersion = '1.2.2'
     def asmVersion = '9.4'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.0.40')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.1.0')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -1204,7 +1204,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.0.1"
+def buildscriptGradleVersion = "8.0.2"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/classic/BWTileEntityDimIDBridge.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/classic/BWTileEntityDimIDBridge.java
@@ -16,4 +16,9 @@ package com.github.bartimaeusnek.bartworks.common.tileentities.classic;
 import net.minecraft.tileentity.TileEntity;
 
 public class BWTileEntityDimIDBridge extends TileEntity {
+
+    @Override
+    public boolean canUpdate() {
+        return false;
+    }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
@@ -86,7 +86,6 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
     private int mExpectedMultiplier = 0;
     private int mTimes = 0;
     private boolean isVisibleFluid = false;
-    private boolean isEverBeenVisibleFluid = false;
 
     public GT_TileEntity_BioVat(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -463,7 +462,6 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
 
     private void placeFluid() {
         isVisibleFluid = true;
-        isEverBeenVisibleFluid = true;
         int xDir = getXDir();
         int zDir = getZDir();
         this.height = this.reCalculateHeight();
@@ -611,7 +609,6 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
         if (this.mFluid != null) aNBT.setString("mFluid", this.mFluid.getName());
         aNBT.setInteger("mSievert", this.mSievert);
         aNBT.setInteger("mNeededSievert", this.mNeededSievert);
-        aNBT.setBoolean("isEverBeenVisibleFluid", this.isEverBeenVisibleFluid);
         aNBT.setBoolean("isVisibleFluid", this.isVisibleFluid);
         super.saveNBTData(aNBT);
     }
@@ -623,7 +620,7 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
             int zDir = getZDir();
             removeFluid(xDir, zDir);
             sendRenderPackets(xDir, zDir);
-        } else if (this.getBaseMetaTileEntity().getWorld().getWorldTime() % 20 == 0 && isEverBeenVisibleFluid) {
+        } else if (this.getBaseMetaTileEntity().getWorld().getWorldTime() % 20 == 7) {
             sendRenderPackets();
         }
 
@@ -676,9 +673,6 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
         this.mSievert = aNBT.getInteger("mSievert");
         this.mNeededSievert = aNBT.getInteger("mNeededSievert");
         super.loadNBTData(aNBT);
-        if (aNBT.hasKey("isEverBeenVisibleFluid")) {
-            this.isEverBeenVisibleFluid = aNBT.getBoolean("isEverBeenVisibleFluid");
-        }
         if (aNBT.hasKey("isVisibleFluid")) {
             this.isVisibleFluid = aNBT.getBoolean("isVisibleFluid");
         }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
@@ -85,6 +85,8 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
     private int mCasing = 0;
     private int mExpectedMultiplier = 0;
     private int mTimes = 0;
+    private boolean isVisibleFluid = false;
+    private boolean isEverBeenVisibleFluid = false;
 
     public GT_TileEntity_BioVat(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -196,7 +198,7 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
 
     /**
      * Calculates the expected output multiplier based on the output hatch
-     * 
+     *
      * @param recipeFluidOutput the recipe fluid output
      * @param needEqual         if the recipeFluidOutput should be equal to the fluid in the output hatch
      * @return the expected output multiplier
@@ -388,8 +390,8 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
     }
 
     private void sendPackagesOrRenewRenderer(int x, int y, int z, BioCulture lCulture) {
-        int xDir = ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetX * 2;
-        int zDir = ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetZ * 2;
+        int xDir = getXDir();
+        int zDir = getZDir();
 
         GT_TileEntity_BioVat.staticColorMap.remove(
                 new Coords(
@@ -460,8 +462,10 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
     }
 
     private void placeFluid() {
-        int xDir = ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetX * 2;
-        int zDir = ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetZ * 2;
+        isVisibleFluid = true;
+        isEverBeenVisibleFluid = true;
+        int xDir = getXDir();
+        int zDir = getZDir();
         this.height = this.reCalculateHeight();
         if (this.mFluid != null && this.height > 1 && this.reCalculateFluidAmmount() > 0) for (int x = -1; x < 2; x++) {
             for (int y = 0; y < this.height; y++) {
@@ -482,6 +486,33 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
         }
     }
 
+    private void removeFluid(int xDir, int zDir) {
+        isVisibleFluid = false;
+
+        for (int x = -1; x < 2; x++) {
+            for (int y = 1; y < 3; y++) {
+                for (int z = -1; z < 2; z++) {
+                    if (this.getBaseMetaTileEntity().getWorld()
+                            .getBlock(
+                                    xDir + x + this.getBaseMetaTileEntity().getXCoord(),
+                                    y + this.getBaseMetaTileEntity().getYCoord(),
+                                    zDir + z + this.getBaseMetaTileEntity().getZCoord())
+                            .equals(FluidLoader.bioFluidBlock))
+                        this.getBaseMetaTileEntity().getWorld().setBlockToAir(
+                                xDir + x + this.getBaseMetaTileEntity().getXCoord(),
+                                y + this.getBaseMetaTileEntity().getYCoord(),
+                                zDir + z + this.getBaseMetaTileEntity().getZCoord());
+                    GT_TileEntity_BioVat.staticColorMap.remove(
+                            new Coords(
+                                    xDir + x + this.getBaseMetaTileEntity().getXCoord(),
+                                    y + this.getBaseMetaTileEntity().getYCoord(),
+                                    zDir + z + this.getBaseMetaTileEntity().getZCoord()),
+                            this.getBaseMetaTileEntity().getWorld().provider.dimensionId);
+                }
+            }
+        }
+    }
+
     private int reCalculateFluidAmmount() {
         return this.getStoredFluids().stream().mapToInt(fluidStack -> fluidStack.amount).sum();
     }
@@ -497,8 +528,8 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
             if (this.mMachine) {
                 ItemStack aStack = this.mInventory[1];
                 BioCulture lCulture = null;
-                int xDir = ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetX * 2;
-                int zDir = ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetZ * 2;
+                int xDir = getXDir();
+                int zDir = getZDir();
 
                 if (this.getBaseMetaTileEntity().getTimer() % 200 == 0) {
                     this.check_Chunk();
@@ -580,49 +611,61 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
         if (this.mFluid != null) aNBT.setString("mFluid", this.mFluid.getName());
         aNBT.setInteger("mSievert", this.mSievert);
         aNBT.setInteger("mNeededSievert", this.mNeededSievert);
+        aNBT.setBoolean("isEverBeenVisibleFluid", this.isEverBeenVisibleFluid);
+        aNBT.setBoolean("isVisibleFluid", this.isVisibleFluid);
         super.saveNBTData(aNBT);
     }
 
     @Override
     public void onRemoval() {
-        int xDir = ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetX * 2;
-        int zDir = ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetZ * 2;
-        for (int x = -1; x < 2; x++) {
-            for (int y = 1; y < 3; y++) {
-                for (int z = -1; z < 2; z++) {
-                    if (this.getBaseMetaTileEntity().getWorld()
-                            .getBlock(
-                                    xDir + x + this.getBaseMetaTileEntity().getXCoord(),
-                                    y + this.getBaseMetaTileEntity().getYCoord(),
-                                    zDir + z + this.getBaseMetaTileEntity().getZCoord())
-                            .equals(FluidLoader.bioFluidBlock))
-                        this.getBaseMetaTileEntity().getWorld().setBlockToAir(
-                                xDir + x + this.getBaseMetaTileEntity().getXCoord(),
-                                y + this.getBaseMetaTileEntity().getYCoord(),
-                                zDir + z + this.getBaseMetaTileEntity().getZCoord());
-                    GT_TileEntity_BioVat.staticColorMap.remove(
-                            new Coords(
-                                    xDir + x + this.getBaseMetaTileEntity().getXCoord(),
-                                    y + this.getBaseMetaTileEntity().getYCoord(),
-                                    zDir + z + this.getBaseMetaTileEntity().getZCoord()),
-                            this.getBaseMetaTileEntity().getWorld().provider.dimensionId);
-                    if (SideReference.Side.Server) MainMod.BW_Network_instance.sendPacketToAllPlayersInRange(
-                            this.getBaseMetaTileEntity().getWorld(),
-                            new RendererPacket(
-                                    new Coords(
-                                            xDir + x + this.getBaseMetaTileEntity().getXCoord(),
-                                            y + this.getBaseMetaTileEntity().getYCoord(),
-                                            zDir + z + this.getBaseMetaTileEntity().getZCoord(),
-                                            this.getBaseMetaTileEntity().getWorld().provider.dimensionId),
-                                    this.mCulture == null ? BioCulture.NULLCULTURE.getColorRGB()
-                                            : this.mCulture.getColorRGB(),
-                                    true),
-                            this.getBaseMetaTileEntity().getXCoord(),
-                            this.getBaseMetaTileEntity().getZCoord());
+        if (isVisibleFluid) {
+            int xDir = getXDir();
+            int zDir = getZDir();
+            removeFluid(xDir, zDir);
+            sendRenderPackets(xDir, zDir);
+        } else if (this.getBaseMetaTileEntity().getWorld().getWorldTime() % 20 == 0 && isEverBeenVisibleFluid) {
+            sendRenderPackets();
+        }
+
+        super.onRemoval();
+    }
+
+    private int getXDir() {
+        return ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetX * 2;
+    }
+
+    private int getZDir() {
+        return ForgeDirection.getOrientation(this.getBaseMetaTileEntity().getBackFacing()).offsetZ * 2;
+    }
+
+    private void sendRenderPackets() {
+        int xDir = getXDir();
+        int zDir = getZDir();
+        sendRenderPackets(xDir, zDir);
+    }
+
+    private void sendRenderPackets(int xDir, int zDir) {
+        if (SideReference.Side.Server) {
+            for (int x = -1; x < 2; x++) {
+                for (int y = 1; y < 3; y++) {
+                    for (int z = -1; z < 2; z++) {
+                        MainMod.BW_Network_instance.sendPacketToAllPlayersInRange(
+                                this.getBaseMetaTileEntity().getWorld(),
+                                new RendererPacket(
+                                        new Coords(
+                                                xDir + x + this.getBaseMetaTileEntity().getXCoord(),
+                                                y + this.getBaseMetaTileEntity().getYCoord(),
+                                                zDir + z + this.getBaseMetaTileEntity().getZCoord(),
+                                                this.getBaseMetaTileEntity().getWorld().provider.dimensionId),
+                                        this.mCulture == null ? BioCulture.NULLCULTURE.getColorRGB()
+                                                : this.mCulture.getColorRGB(),
+                                        true),
+                                this.getBaseMetaTileEntity().getXCoord(),
+                                this.getBaseMetaTileEntity().getZCoord());
+                    }
                 }
             }
         }
-        super.onRemoval();
     }
 
     @Override
@@ -633,6 +676,12 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
         this.mSievert = aNBT.getInteger("mSievert");
         this.mNeededSievert = aNBT.getInteger("mNeededSievert");
         super.loadNBTData(aNBT);
+        if (aNBT.hasKey("isEverBeenVisibleFluid")) {
+            this.isEverBeenVisibleFluid = aNBT.getBoolean("isEverBeenVisibleFluid");
+        }
+        if (aNBT.hasKey("isVisibleFluid")) {
+            this.isVisibleFluid = aNBT.getBoolean("isVisibleFluid");
+        }
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
@@ -673,9 +673,7 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
         this.mSievert = aNBT.getInteger("mSievert");
         this.mNeededSievert = aNBT.getInteger("mNeededSievert");
         super.loadNBTData(aNBT);
-        if (aNBT.hasKey("isVisibleFluid")) {
-            this.isVisibleFluid = aNBT.getBoolean("isVisibleFluid");
-        }
+        this.isVisibleFluid = aNBT.getBoolean("isVisibleFluid");
     }
 
     @Override


### PR DESCRIPTION
* Reduces amount of sent render packets (from one per tick to one per 10 second) when multiblock is incomplete
* disable ticking for tileEntity which are needed to display fluids
+ bs + sa