### PR TITLE
Add Humongous input hatch

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ItemRegistry.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ItemRegistry.java
@@ -211,6 +211,8 @@ public class ItemRegistry {
     public static ItemStack eic;
     public static ItemStack cal;
     public static ItemStack compressedHatch;
+    public static ItemStack heliumHatch;
+    public static ItemStack hydrogenHatch;
     public static ItemStack giantOutputHatch;
 
     public static ItemStack[][][] TecTechLaserAdditions = new ItemStack[3][4][4];
@@ -346,7 +348,18 @@ public class ItemRegistry {
             ItemRegistry.compressedHatch = new GT_MetaTileEntity_CompressedFluidHatch(
                     ConfigHandler.IDOffset + GT_Values.VN.length * 8 + 8,
                     "CompressedFluidHatch",
-                    "Liquid Air Fluid Hatch").getStackForm(1L);
+                    "Liquid Air Fluid Hatch",
+                    Materials.LiquidAir.getFluid(1)).getStackForm(1L);
+            ItemRegistry.hydrogenHatch = new GT_MetaTileEntity_CompressedFluidHatch(
+                    ConfigHandler.IDOffset + GT_Values.VN.length * 9 + 55,
+                    "HydrogenHatch",
+                    "Hydrogen Input Hatch",
+                    Materials.Hydrogen.getGas(1)).getStackForm(1L);
+            ItemRegistry.heliumHatch = new GT_MetaTileEntity_CompressedFluidHatch(
+                    ConfigHandler.IDOffset + GT_Values.VN.length * 9 + 56,
+                    "HeliumHatch",
+                    "Helium Input Hatch",
+                    Materials.Helium.getGas(1)).getStackForm(1L);
             ItemRegistry.giantOutputHatch = new GT_MetaTileEntity_GiantOutputHatch(
                     ConfigHandler.IDOffset + GT_Values.VN.length * 8 + 9,
                     "GiantOutputHatch",

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ItemRegistry.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ItemRegistry.java
@@ -353,9 +353,9 @@ public class ItemRegistry {
                     "GiantOutputHatch",
                     "Giant Output Hatch").getStackForm(1L);
             ItemRegistry.humongousInputHatch = new GT_MetaTileEntity_HumongousInputHatch(
-                ConfigHandler.IDOffset + GT_Values.VN.length * 9 + 55,
-                "HumongousInputHatch",
-                "Humongous Input Hatch").getStackForm(1L);
+                    ConfigHandler.IDOffset + GT_Values.VN.length * 9 + 55,
+                    "HumongousInputHatch",
+                    "Humongous Input Hatch").getStackForm(1L);
             ItemRegistry.megaMachines[2] = new GT_TileEntity_MegaDistillTower(
                     ConfigHandler.IDOffset + GT_Values.VN.length * 8 + 10,
                     "MegaDistillationTower",

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ItemRegistry.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ItemRegistry.java
@@ -211,8 +211,6 @@ public class ItemRegistry {
     public static ItemStack eic;
     public static ItemStack cal;
     public static ItemStack compressedHatch;
-    public static ItemStack heliumHatch;
-    public static ItemStack hydrogenHatch;
     public static ItemStack giantOutputHatch;
 
     public static ItemStack[][][] TecTechLaserAdditions = new ItemStack[3][4][4];
@@ -348,18 +346,7 @@ public class ItemRegistry {
             ItemRegistry.compressedHatch = new GT_MetaTileEntity_CompressedFluidHatch(
                     ConfigHandler.IDOffset + GT_Values.VN.length * 8 + 8,
                     "CompressedFluidHatch",
-                    "Liquid Air Fluid Hatch",
-                    Materials.LiquidAir.getFluid(1)).getStackForm(1L);
-            ItemRegistry.hydrogenHatch = new GT_MetaTileEntity_CompressedFluidHatch(
-                    ConfigHandler.IDOffset + GT_Values.VN.length * 9 + 55,
-                    "HydrogenHatch",
-                    "Hydrogen Input Hatch",
-                    Materials.Hydrogen.getGas(1)).getStackForm(1L);
-            ItemRegistry.heliumHatch = new GT_MetaTileEntity_CompressedFluidHatch(
-                    ConfigHandler.IDOffset + GT_Values.VN.length * 9 + 56,
-                    "HeliumHatch",
-                    "Helium Input Hatch",
-                    Materials.Helium.getGas(1)).getStackForm(1L);
+                    "Liquid Air Fluid Hatch").getStackForm(1L);
             ItemRegistry.giantOutputHatch = new GT_MetaTileEntity_GiantOutputHatch(
                     ConfigHandler.IDOffset + GT_Values.VN.length * 8 + 9,
                     "GiantOutputHatch",

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ItemRegistry.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ItemRegistry.java
@@ -212,6 +212,7 @@ public class ItemRegistry {
     public static ItemStack cal;
     public static ItemStack compressedHatch;
     public static ItemStack giantOutputHatch;
+    public static ItemStack humongousInputHatch;
 
     public static ItemStack[][][] TecTechLaserAdditions = new ItemStack[3][4][4];
     public static ItemStack TecTechPipeEnergyLowPower;
@@ -351,6 +352,10 @@ public class ItemRegistry {
                     ConfigHandler.IDOffset + GT_Values.VN.length * 8 + 9,
                     "GiantOutputHatch",
                     "Giant Output Hatch").getStackForm(1L);
+            ItemRegistry.humongousInputHatch = new GT_MetaTileEntity_HumongousInputHatch(
+                ConfigHandler.IDOffset + GT_Values.VN.length * 9 + 55,
+                "HumongousInputHatch",
+                "Humongous Input Hatch").getStackForm(1L);
             ItemRegistry.megaMachines[2] = new GT_TileEntity_MegaDistillTower(
                     ConfigHandler.IDOffset + GT_Values.VN.length * 8 + 10,
                     "MegaDistillationTower",

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/RecipeLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/RecipeLoader.java
@@ -930,6 +930,32 @@ public class RecipeLoader {
             GT_Recipe.GT_Recipe_Map.sAssemblerRecipes.add(
                     new BWRecipes.DynamicGTRecipe(
                             false,
+                            new ItemStack[] { ItemList.Hatch_Input_HV.get(64), Materials.Helium.getCells(1),
+                                    GT_Utility.getIntegratedCircuit(17) },
+                            new ItemStack[] { ItemRegistry.heliumHatch.copy() },
+                            null,
+                            null,
+                            null,
+                            null,
+                            300,
+                            BW_Util.getMachineVoltageFromTier(3),
+                            0));
+            GT_Recipe.GT_Recipe_Map.sAssemblerRecipes.add(
+                    new BWRecipes.DynamicGTRecipe(
+                            false,
+                            new ItemStack[] { ItemList.Hatch_Input_HV.get(64), Materials.Hydrogen.getCells(1),
+                                    GT_Utility.getIntegratedCircuit(17) },
+                            new ItemStack[] { ItemRegistry.hydrogenHatch.copy() },
+                            null,
+                            null,
+                            null,
+                            null,
+                            300,
+                            BW_Util.getMachineVoltageFromTier(3),
+                            0));
+            GT_Recipe.GT_Recipe_Map.sAssemblerRecipes.add(
+                    new BWRecipes.DynamicGTRecipe(
+                            false,
                             new ItemStack[] { ItemList.Hatch_Output_HV.get(64), GT_Utility.getIntegratedCircuit(17) },
                             new ItemStack[] { ItemRegistry.giantOutputHatch.copy() },
                             null,

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/RecipeLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/RecipeLoader.java
@@ -930,32 +930,6 @@ public class RecipeLoader {
             GT_Recipe.GT_Recipe_Map.sAssemblerRecipes.add(
                     new BWRecipes.DynamicGTRecipe(
                             false,
-                            new ItemStack[] { ItemList.Hatch_Input_HV.get(64), Materials.Helium.getCells(1),
-                                    GT_Utility.getIntegratedCircuit(17) },
-                            new ItemStack[] { ItemRegistry.heliumHatch.copy() },
-                            null,
-                            null,
-                            null,
-                            null,
-                            300,
-                            BW_Util.getMachineVoltageFromTier(3),
-                            0));
-            GT_Recipe.GT_Recipe_Map.sAssemblerRecipes.add(
-                    new BWRecipes.DynamicGTRecipe(
-                            false,
-                            new ItemStack[] { ItemList.Hatch_Input_HV.get(64), Materials.Hydrogen.getCells(1),
-                                    GT_Utility.getIntegratedCircuit(17) },
-                            new ItemStack[] { ItemRegistry.hydrogenHatch.copy() },
-                            null,
-                            null,
-                            null,
-                            null,
-                            300,
-                            BW_Util.getMachineVoltageFromTier(3),
-                            0));
-            GT_Recipe.GT_Recipe_Map.sAssemblerRecipes.add(
-                    new BWRecipes.DynamicGTRecipe(
-                            false,
                             new ItemStack[] { ItemList.Hatch_Output_HV.get(64), GT_Utility.getIntegratedCircuit(17) },
                             new ItemStack[] { ItemRegistry.giantOutputHatch.copy() },
                             null,

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
@@ -25,24 +25,29 @@ import gregtech.common.gui.modularui.widget.FluidDisplaySlotWidget;
 
 public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Hatch_Input {
 
-    public GT_MetaTileEntity_CompressedFluidHatch(int aID, String aName, String aNameRegional) {
+    private final FluidStack allowedFluid;
+
+    public GT_MetaTileEntity_CompressedFluidHatch(int aID, String aName, String aNameRegional,
+            FluidStack aAllowedFluid) {
         super(aID, aName, aNameRegional, 0);
-        this.mDescriptionArray[1] = "Capacity: 100000000L";
+        this.mDescriptionArray[1] = "Capacity: 2,000,000,000L";
+        allowedFluid = aAllowedFluid;
     }
 
     public GT_MetaTileEntity_CompressedFluidHatch(String aName, int aTier, String[] aDescription,
-            ITexture[][][] aTextures) {
+            FluidStack aAllowedFluid, ITexture[][][] aTextures) {
         super(aName, aTier, aDescription, aTextures);
+        allowedFluid = aAllowedFluid;
     }
 
     @Override
     public int getCapacity() {
-        return 100000000;
+        return 2000000000;
     }
 
     @Override
     public boolean isFluidInputAllowed(FluidStack aFluid) {
-        return GT_Utility.areFluidsEqual(aFluid, Materials.LiquidAir.getFluid(1));
+        return GT_Utility.areFluidsEqual(aFluid, allowedFluid);
     }
 
     @Override
@@ -51,11 +56,19 @@ public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Ha
                 this.mName,
                 this.mTier,
                 this.mDescriptionArray,
+                this.allowedFluid,
                 this.mTextures);
     }
 
     @Override
     protected FluidDisplaySlotWidget createDrainableFluidSlot() {
-        return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.LiquidAir.mFluid);
+        if (Materials.LiquidAir.getFluid(1).equals(allowedFluid)) {
+            return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.LiquidAir.mFluid);
+        } else if (Materials.Helium.getGas(1).equals(allowedFluid)) {
+            return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.Helium.mGas);
+        } else if (Materials.Hydrogen.getGas(1).equals(allowedFluid)) {
+            return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.Hydrogen.mGas);
+        }
+        return super.createDrainableFluidSlot().setEmptyCanFillFilter(null);
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
@@ -27,7 +27,7 @@ public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Ha
 
     public GT_MetaTileEntity_CompressedFluidHatch(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional, 0);
-        this.mDescriptionArray[1] = "Capacity: 100000000L";
+        this.mDescriptionArray[1] = "Capacity: 100,000,000L";
     }
 
     public GT_MetaTileEntity_CompressedFluidHatch(String aName, int aTier, String[] aDescription,

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
@@ -37,7 +37,7 @@ public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Ha
 
     @Override
     public int getCapacity() {
-        return 100000000;
+        return 100_000_000;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_CompressedFluidHatch.java
@@ -25,29 +25,24 @@ import gregtech.common.gui.modularui.widget.FluidDisplaySlotWidget;
 
 public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Hatch_Input {
 
-    private final FluidStack allowedFluid;
-
-    public GT_MetaTileEntity_CompressedFluidHatch(int aID, String aName, String aNameRegional,
-            FluidStack aAllowedFluid) {
+    public GT_MetaTileEntity_CompressedFluidHatch(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional, 0);
-        this.mDescriptionArray[1] = "Capacity: 2,000,000,000L";
-        allowedFluid = aAllowedFluid;
+        this.mDescriptionArray[1] = "Capacity: 100000000L";
     }
 
     public GT_MetaTileEntity_CompressedFluidHatch(String aName, int aTier, String[] aDescription,
-            FluidStack aAllowedFluid, ITexture[][][] aTextures) {
+            ITexture[][][] aTextures) {
         super(aName, aTier, aDescription, aTextures);
-        allowedFluid = aAllowedFluid;
     }
 
     @Override
     public int getCapacity() {
-        return 2000000000;
+        return 100000000;
     }
 
     @Override
     public boolean isFluidInputAllowed(FluidStack aFluid) {
-        return GT_Utility.areFluidsEqual(aFluid, allowedFluid);
+        return GT_Utility.areFluidsEqual(aFluid, Materials.LiquidAir.getFluid(1));
     }
 
     @Override
@@ -56,19 +51,11 @@ public class GT_MetaTileEntity_CompressedFluidHatch extends GT_MetaTileEntity_Ha
                 this.mName,
                 this.mTier,
                 this.mDescriptionArray,
-                this.allowedFluid,
                 this.mTextures);
     }
 
     @Override
     protected FluidDisplaySlotWidget createDrainableFluidSlot() {
-        if (Materials.LiquidAir.getFluid(1).equals(allowedFluid)) {
-            return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.LiquidAir.mFluid);
-        } else if (Materials.Helium.getGas(1).equals(allowedFluid)) {
-            return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.Helium.mGas);
-        } else if (Materials.Hydrogen.getGas(1).equals(allowedFluid)) {
-            return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.Hydrogen.mGas);
-        }
-        return super.createDrainableFluidSlot().setEmptyCanFillFilter(null);
+        return super.createDrainableFluidSlot().setEmptyCanFillFilter(f -> f == Materials.LiquidAir.mFluid);
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_HumongousInputHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_HumongousInputHatch.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018-2020 bartimaeusnek Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions: The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.github.bartimaeusnek.bartworks.common.tileentities.tiered;
+
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Input;
+import gregtech.common.gui.modularui.widget.FluidDisplaySlotWidget;
+
+public class GT_MetaTileEntity_HumongousInputHatch extends GT_MetaTileEntity_Hatch_Input {
+
+    public GT_MetaTileEntity_HumongousInputHatch(int aID, String aName, String aNameRegional) {
+        super(aID, aName, aNameRegional, 0);
+        this.mDescriptionArray[1] = "Capacity: 2,000,000,000L";
+    }
+
+    public GT_MetaTileEntity_HumongousInputHatch(String aName, int aTier, String[] aDescription,
+                                                  ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+    }
+
+    @Override
+    public int getCapacity() {
+        return 2000000000;
+    }
+
+
+    @Override
+    public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_HumongousInputHatch(
+            this.mName,
+            this.mTier,
+            this.mDescriptionArray,
+            this.mTextures);
+    }
+
+    @Override
+    protected FluidDisplaySlotWidget createDrainableFluidSlot() {
+        return super.createDrainableFluidSlot();
+    }
+}

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_HumongousInputHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_HumongousInputHatch.java
@@ -33,7 +33,7 @@ public class GT_MetaTileEntity_HumongousInputHatch extends GT_MetaTileEntity_Hat
 
     @Override
     public int getCapacity() {
-        return 2000000000;
+        return 2_000_000_000;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_HumongousInputHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_HumongousInputHatch.java
@@ -27,7 +27,7 @@ public class GT_MetaTileEntity_HumongousInputHatch extends GT_MetaTileEntity_Hat
     }
 
     public GT_MetaTileEntity_HumongousInputHatch(String aName, int aTier, String[] aDescription,
-                                                  ITexture[][][] aTextures) {
+            ITexture[][][] aTextures) {
         super(aName, aTier, aDescription, aTextures);
     }
 
@@ -36,14 +36,13 @@ public class GT_MetaTileEntity_HumongousInputHatch extends GT_MetaTileEntity_Hat
         return 2000000000;
     }
 
-
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_HumongousInputHatch(
-            this.mName,
-            this.mTier,
-            this.mDescriptionArray,
-            this.mTextures);
+                this.mName,
+                this.mTier,
+                this.mDescriptionArray,
+                this.mTextures);
     }
 
     @Override


### PR DESCRIPTION
OUTDATED:
Adds large helium and hydrogen hatches which only accepts their fluid like the liquid air hatch. 
The main usecase for these hatches is the eye of harmony which needs billions of liters of these fluids.
Therefore these hatches have a massive internal buffer of 2 billion L.

This PR also buffs the capacity of the liquid air hatch as a consequence, but I believe that should not be an issue

NEW:
Adds the humongous input hatch, basically an input hatch with 2 billion L capacity.
Recipe will be added in coremod


