### PR TITLE
EIC - Fix overclock and support void protection

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
@@ -288,6 +288,10 @@ public class GT_TileEntity_ElectricImplosionCompressor
                 helper.enableBatchMode(128);
             }
 
+            if (!voidExcess) {
+                helper.enableVoidProtection(this);
+            }
+
             helper.build();
 
             if (helper.getCurrentParallel() == 0) {
@@ -527,6 +531,11 @@ public class GT_TileEntity_ElectricImplosionCompressor
 
     @Override
     protected boolean isBatchModeButtonEnabled() {
+        return true;
+    }
+
+    @Override
+    protected boolean isVoidExcessButtonEnabled() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
@@ -452,6 +452,7 @@ public class GT_TileEntity_ElectricImplosionCompressor
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack itemStack) {
         this.mCasing = 0;
+        this.mMaxHatchTier = 0;
         setBlockTier(0);
         boolean isOK = checkPiece(STRUCTURE_PIECE_MAIN, 1, 6, 0);
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
@@ -46,7 +46,13 @@ import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentLimits;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
-import com.gtnewhorizon.structurelib.structure.*;
+import com.gtnewhorizon.structurelib.structure.AutoPlaceEnvironment;
+import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
+import com.gtnewhorizon.structurelib.structure.IStructureElement;
+import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
+import com.gtnewhorizon.structurelib.structure.ITierConverter;
+import com.gtnewhorizon.structurelib.structure.StructureDefinition;
+import com.gtnewhorizon.structurelib.structure.StructureUtility;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -60,7 +66,11 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_ExtendedPowerMultiBlockBase;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.*;
+import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_OverclockCalculator;
+import gregtech.api.util.GT_ParallelHelper;
+import gregtech.api.util.GT_Recipe;
+import gregtech.api.util.GT_Utility;
 
 public class GT_TileEntity_ElectricImplosionCompressor
         extends GT_MetaTileEntity_ExtendedPowerMultiBlockBase<GT_TileEntity_ElectricImplosionCompressor>


### PR DESCRIPTION
- Fix tier skip overclock
- Only allow a single tier skip OC (minimum energy hatch tier is recipe tier - 1)
- Support void protection