### PR TITLE
Add oredicts for diode and inductor for 2A-16A diode

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/recipes/CraftingRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/recipes/CraftingRecipes.java
@@ -213,13 +213,6 @@ public class CraftingRecipes implements Runnable {
                                 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GT_OreDictUnificator.get(OrePrefixes.wireGt16, cable, 1L), 'P', hull, 'C',
                                 machinehull });
-                GT_ModHandler.addCraftingRecipe(
-                        ItemRegistry.diode16A[i],
-                        RecipeLoader.BITSD,
-                        new Object[] { "WHW", "DCD", "PDP", 'H', ItemList.Circuit_Parts_Coil.get(1L), 'D',
-                                ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
-                                GT_OreDictUnificator.get(OrePrefixes.wireGt16, cable, 1L), 'P', hull, 'C',
-                                machinehull });
 
             } catch (ArrayIndexOutOfBoundsException ignored) {
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/recipes/CraftingRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/recipes/CraftingRecipes.java
@@ -185,64 +185,32 @@ public class CraftingRecipes implements Runnable {
                 GT_ModHandler.addCraftingRecipe(
                         ItemRegistry.diode12A[i],
                         RecipeLoader.BITSD,
-                        new Object[] { "WDW", "DCD", "PDP", 'D',
-                                ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                GT_OreDictUnificator.get(OrePrefixes.cableGt12, cable, 1L), 'P', hull, 'C',
-                                machinehull });
-                GT_ModHandler.addCraftingRecipe(
-                        ItemRegistry.diode12A[i],
-                        RecipeLoader.BITSD,
-                        new Object[] { "WDW", "DCD", "PDP", 'D',
-                                ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                        new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GT_OreDictUnificator.get(OrePrefixes.cableGt12, cable, 1L), 'P', hull, 'C',
                                 machinehull });
                 GT_ModHandler.addCraftingRecipe(
                         ItemRegistry.diode8A[i],
                         RecipeLoader.BITSD,
-                        new Object[] { "WDW", "DCD", "PDP", 'D',
-                                ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                GT_OreDictUnificator.get(OrePrefixes.cableGt08, cable, 1L), 'P', hull, 'C',
-                                machinehull });
-                GT_ModHandler.addCraftingRecipe(
-                        ItemRegistry.diode8A[i],
-                        RecipeLoader.BITSD,
-                        new Object[] { "WDW", "DCD", "PDP", 'D',
-                                ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                        new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GT_OreDictUnificator.get(OrePrefixes.cableGt08, cable, 1L), 'P', hull, 'C',
                                 machinehull });
                 GT_ModHandler.addCraftingRecipe(
                         ItemRegistry.diode4A[i],
                         RecipeLoader.BITSD,
-                        new Object[] { "WDW", "DCD", "PDP", 'D',
-                                ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                GT_OreDictUnificator.get(OrePrefixes.cableGt04, cable, 1L), 'P', hull, 'C',
-                                machinehull });
-                GT_ModHandler.addCraftingRecipe(
-                        ItemRegistry.diode4A[i],
-                        RecipeLoader.BITSD,
-                        new Object[] { "WDW", "DCD", "PDP", 'D',
-                                ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                        new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GT_OreDictUnificator.get(OrePrefixes.cableGt04, cable, 1L), 'P', hull, 'C',
                                 machinehull });
                 GT_ModHandler.addCraftingRecipe(
                         ItemRegistry.diode2A[i],
                         RecipeLoader.BITSD,
-                        new Object[] { "WDW", "DCD", "PDP", 'D',
-                                ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                GT_OreDictUnificator.get(OrePrefixes.cableGt02, cable, 1L), 'P', hull, 'C',
-                                machinehull });
-                GT_ModHandler.addCraftingRecipe(
-                        ItemRegistry.diode2A[i],
-                        RecipeLoader.BITSD,
-                        new Object[] { "WDW", "DCD", "PDP", 'D',
-                                ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                        new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GT_OreDictUnificator.get(OrePrefixes.cableGt02, cable, 1L), 'P', hull, 'C',
                                 machinehull });
                 GT_ModHandler.addCraftingRecipe(
                         ItemRegistry.diode16A[i],
                         RecipeLoader.BITSD,
-                        new Object[] { "WHW", "DCD", "PDP", 'H', ItemList.Circuit_Parts_Coil.get(1L), 'D',
-                                ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
+                        new Object[] { "WHW", "DCD", "PDP", 'H', OrePrefixes.componentCircuit.get(Materials.Inductor),
+                                'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GT_OreDictUnificator.get(OrePrefixes.wireGt16, cable, 1L), 'P', hull, 'C',
                                 machinehull });
                 GT_ModHandler.addCraftingRecipe(


### PR DESCRIPTION
- this allows smd inductors in 16A diodes which adresses https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13250 on the bartworks side. (higher tiers were done in coremod)
- instead of 2 separate recipes there is now only one with cycling ingredients as it should be.

this is the last part, so this closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13250