### PR TITLE
Allow scanners to display heat of MEBFs.

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -45,6 +45,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -308,6 +309,15 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
                 || addInputToMachineList(aTileEntity, aBaseCasingIndex)
                 || addOutputToMachineList(aTileEntity, aBaseCasingIndex)
                 || addEnergyInputToMachineList(aTileEntity, aBaseCasingIndex);
+    }
+
+    @Override
+    protected String[] getExtendedInfoData() {
+        return new String[] { StatCollector.translateToLocal("GT5U.EBF.heat") + ": "
+                + EnumChatFormatting.GREEN
+                + GT_Utility.formatNumbers(mHeatingCapacity)
+                + EnumChatFormatting.RESET
+                + " K" };
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaMultiBlockBase.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaMultiBlockBase.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.GT_Values.V;
 import static gregtech.api.enums.Mods.TecTech;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -137,6 +138,10 @@ public abstract class GT_TileEntity_MegaMultiBlockBase<T extends GT_TileEntity_M
         return TecTech.isModLoaded() ? this.getInfoDataArray(this) : super.getInfoData();
     }
 
+    protected String[] getExtendedInfoData() {
+        return new String[0];
+    }
+
     @Override
     public String[] getInfoDataArray(GT_MetaTileEntity_MultiBlockBase multiBlockBase) {
         int mPollutionReduction = 0;
@@ -163,7 +168,9 @@ public abstract class GT_TileEntity_MegaMultiBlockBase<T extends GT_TileEntity_M
         String tName = BW_Util.getTierNameFromVoltage(nominalV);
         if (tName.equals("MAX+")) tName = EnumChatFormatting.OBFUSCATED + "MAX+";
 
-        return new String[] {
+        String[] extendedInfo = getExtendedInfoData();
+
+        String[] baseInfo = new String[] {
                 StatCollector.translateToLocal("GT5U.multiblock.Progress") + ": "
                         + EnumChatFormatting.GREEN
                         + GT_Utility.formatNumbers(this.mProgresstime / 20)
@@ -216,8 +223,15 @@ public abstract class GT_TileEntity_MegaMultiBlockBase<T extends GT_TileEntity_M
                         + EnumChatFormatting.GREEN
                         + mPollutionReduction
                         + EnumChatFormatting.RESET
-                        + " %",
-                BW_Tooltip_Reference.BW };
+                        + " %" };
+
+        String[] combinedInfo = Arrays.copyOf(baseInfo, baseInfo.length + extendedInfo.length + 1);
+
+        System.arraycopy(extendedInfo, 0, combinedInfo, baseInfo.length, extendedInfo.length);
+
+        combinedInfo[combinedInfo.length - 1] = BW_Tooltip_Reference.BW;
+
+        return combinedInfo;
     }
 
     /**


### PR DESCRIPTION
Many people were confused (including me) about heat levels on MEBFs since compared to a regular EBF it does not show computed heat level. This directly shows correct heat level when using a scanner on the controller.

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/2588062/235350327-218cb44c-f051-4047-8b11-6ec0581a992f.png">
