### PR TITLE
Move Ross128 system closer to solar system

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticraft/solarsystems/Ross128SolarSystem.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticraft/solarsystems/Ross128SolarSystem.java
@@ -48,7 +48,7 @@ public class Ross128SolarSystem {
     public static void init() {
 
         Ross128SolarSystem.Ross128System = new SolarSystem("Ross128System", "milkyWay")
-                .setMapPosition(new Vector3(-1.0D, 1.3D, 0.0D));
+                .setMapPosition(new Vector3(-0.3D, 0.4D, 0.0D));
         Ross128SolarSystem.Ross128 = (Star) new Star("Ross128").setParentSolarSystem(Ross128SolarSystem.Ross128System)
                 .setTierRequired(-1);
         Ross128SolarSystem.Ross128.setUnreachable();


### PR DESCRIPTION
As a T3 system, it shouldn't be as far away as the T8 systems.

New position:
![grafik](https://github.com/GTNewHorizons/bartworks/assets/35727266/d3dbedb6-e458-4581-9815-270ae555ba54)