### PR TITLE
Add eternity mhdcsm recipes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.21:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.39:dev')
     api("com.github.GTNewHorizons:TecTech:5.2.5:dev")
     api("com.github.GTNewHorizons:GalacticGregGT5:1.0.9:dev") {
         exclude group:"com.github.GTNewHorizons", module:"bartworks"

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
@@ -116,6 +116,18 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
                 20 * 4,
                 (int) TierEU.RECIPE_UXV);
 
+        // MHDCSM V2
+        addElectricImplosionRecipe(
+                // IN.
+                new ItemStack[] { MaterialsUEVplus.Eternity.getNanite(1), MaterialsUEVplus.Universium.getNanite(1) },
+                new FluidStack[] { MaterialsUEVplus.RawStarMatter.getFluid(128 * 144L) },
+                // OUT.
+                new ItemStack[] { GT_Values.NI },
+                new FluidStack[] { MaterialsUEVplus.MagnetohydrodynamicallyConstrainedStarMatter.getMolten(32 * 144L) },
+                // Recipe stats.
+                20 * 4,
+                (int) TierEU.RECIPE_MAX);
+
         addMagnetohydrodynamicallyConstrainedStarMatterPartRecipes();
     }
 
@@ -152,7 +164,7 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
                     new ItemStack[] { circuit.splitStack(circuitMultiplier),
                             getModItem(SuperSolarPanels.ID, "solarsplitter", 1, 0),
                             getModItem(OpenComputers.ID, "hologram2", circuitMultiplier, 0),
-                            GT_OreDictUnificator.get(part, MaterialsUEVplus.Universium, multiplier), },
+                            GT_OreDictUnificator.get(part, MaterialsUEVplus.Eternity, multiplier), },
                     new FluidStack[] { MaterialsUEVplus.MagnetohydrodynamicallyConstrainedStarMatter
                             .getMolten((long) partFraction * multiplier) },
                     new ItemStack[] { GT_OreDictUnificator


### PR DESCRIPTION
The bartworks part of the eternity changes, adds a better mhdcsm recipe using eternity nanites and replaces universium parts in mhdcsm part recipes with eternity parts.
Coremod changes will follow soon.

![image](https://github.com/GTNewHorizons/bartworks/assets/93287602/7370f508-052d-475a-80f0-ed4ecbe80b8b)
![image](https://github.com/GTNewHorizons/bartworks/assets/93287602/f5dc7446-8aca-472a-982d-b266d140a1d9)
