### PR TITLE
Update to new void protection API & implement it for some multi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1683563728
+//version: 1684218858
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -569,9 +569,10 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.6"
+def mixinProviderVersion = "0.1.7.1"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+ext.mixinProviderSpec = mixinProviderSpec
 
 dependencies {
     if (usesMixins.toBoolean()) {
@@ -729,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -821,6 +822,18 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
         }
         this.classpath(project.java17DependenciesCfg)
+    }
+
+    public void setup(Project project) {
+        super.setup(project)
+        if (project.usesMixins.toBoolean()) {
+            this.extraJvmArgs.addAll(project.provider(() -> {
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                mixinCfg.canBeConsumed = false
+                mixinCfg.transitive = false
+                enableHotswap ? ["-javaagent:" + mixinCfg.singleFile.absolutePath] : []
+            }))
+        }
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.56-pre:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.57-pre:dev')
     api("com.github.GTNewHorizons:TecTech:5.2.18:dev")
     api("com.github.GTNewHorizons:GalacticGregGT5:1.0.9:dev") {
         exclude group:"com.github.GTNewHorizons", module:"bartworks"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.55-pre:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.56-pre:dev')
     api("com.github.GTNewHorizons:TecTech:5.2.18:dev")
     api("com.github.GTNewHorizons:GalacticGregGT5:1.0.9:dev") {
         exclude group:"com.github.GTNewHorizons", module:"bartworks"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,13 +1,13 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.39:dev')
-    api("com.github.GTNewHorizons:TecTech:5.2.5:dev")
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.55-pre:dev')
+    api("com.github.GTNewHorizons:TecTech:5.2.18:dev")
     api("com.github.GTNewHorizons:GalacticGregGT5:1.0.9:dev") {
         exclude group:"com.github.GTNewHorizons", module:"bartworks"
     }
-    api("com.github.GTNewHorizons:Avaritia:1.39:dev")
-    implementation("com.github.GTNewHorizons:TinkersConstruct:1.9.31-GTNH:dev")
+    api("com.github.GTNewHorizons:Avaritia:1.42:dev")
+    implementation("com.github.GTNewHorizons:TinkersConstruct:1.9.35-GTNH:dev")
 
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.23:deobf") {transitive = false}
     compileOnly("com.github.GTNewHorizons:OpenComputers:1.9.5-GTNH:api") {transitive = false}

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_BioVat.java
@@ -312,6 +312,7 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
         this.mEfficiency = (10000 - (this.getIdealStatus() - this.getRepairStatus()) * 1000);
         this.mEfficiencyIncrease = 10000;
 
+        if (!canOutputAll(gtRecipe)) return false;
         if (!gtRecipe.isRecipeInputEqual(true, tFluids, tInputs)) return false;
 
         final FluidStack recipeFluidOutput = gtRecipe.getFluidOutput(0);
@@ -738,5 +739,10 @@ public class GT_TileEntity_BioVat extends GT_MetaTileEntity_EnhancedMultiBlockBa
                 + EnumChatFormatting.RESET
                 + " %";
         return infoData;
+    }
+
+    @Override
+    public boolean supportsVoidProtection() {
+        return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -233,6 +233,7 @@ public class GT_TileEntity_CircuitAssemblyLine extends
         }
 
         for (GT_Recipe recipe : this.GT_RECIPE_COLLECTION) {
+            if (!canOutputAll(recipe)) return false;
             if (recipe.isRecipeInputEqual(
                     true,
                     false,
@@ -439,7 +440,12 @@ public class GT_TileEntity_CircuitAssemblyLine extends
     }
 
     @Override
-    protected boolean isRecipeLockingEnabled() {
+    public boolean supportsVoidProtection() {
+        return true;
+    }
+
+    @Override
+    public boolean isRecipeLockingEnabled() {
         return imprintedItemName != null && !imprintedItemName.equals("");
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
@@ -285,14 +285,10 @@ public class GT_TileEntity_ElectricImplosionCompressor
 
             GT_ParallelHelper helper = new GT_ParallelHelper().setRecipe(tRecipe).setItemInputs(tItemInputs)
                     .setFluidInputs(tFluidInputs).setAvailableEUt(tTotalEU).setMaxParallel(tCurrentMaxParallel)
-                    .enableConsumption().enableOutputCalculation();
+                    .enableConsumption().enableOutputCalculation().setController(this);
 
             if (batchMode) {
                 helper.enableBatchMode(128);
-            }
-
-            if (!voidExcess) {
-                helper.enableVoidProtection(this);
             }
 
             helper.build();
@@ -540,12 +536,12 @@ public class GT_TileEntity_ElectricImplosionCompressor
     }
 
     @Override
-    protected boolean isBatchModeButtonEnabled() {
+    public boolean isBatchModeButtonEnabled() {
         return true;
     }
 
     @Override
-    protected boolean isVoidExcessButtonEnabled() {
+    public boolean supportsVoidProtection() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_ElectricImplosionCompressor.java
@@ -536,7 +536,7 @@ public class GT_TileEntity_ElectricImplosionCompressor
     }
 
     @Override
-    public boolean isBatchModeButtonEnabled() {
+    public boolean supportsBatchMode() {
         return true;
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_HTGR.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_HTGR.java
@@ -290,7 +290,7 @@ public class GT_TileEntity_HTGR extends GT_MetaTileEntity_EnhancedMultiBlockBase
 
         int toReduce = MathUtils.floorInt((double) this.fuelsupply * 0.025D * eff);
 
-        this.fuelsupply -= toReduce;
+        final int originalToReduce = toReduce;
         int burnedballs = toReduce / 64;
         if (burnedballs > 0) toReduce -= burnedballs * 64;
 
@@ -300,6 +300,7 @@ public class GT_TileEntity_HTGR extends GT_MetaTileEntity_EnhancedMultiBlockBase
                 new ItemStack(HTGRMaterials.aHTGR_Materials, toReduce, meta + 1) };
         if (!canOutputAll(toOutput)) return false;
 
+        this.fuelsupply -= originalToReduce;
         this.mOutputItems = toOutput;
 
         // this.updateSlots(); // not needed ?

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_HTGR.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_HTGR.java
@@ -296,8 +296,11 @@ public class GT_TileEntity_HTGR extends GT_MetaTileEntity_EnhancedMultiBlockBase
 
         int meta = (this.fueltype * HTGRMaterials.MATERIALS_PER_FUEL) + HTGRMaterials.BURNED_OUT_FUEL_INDEX;
 
-        this.mOutputItems = new ItemStack[] { new ItemStack(HTGRMaterials.aHTGR_Materials, burnedballs, meta),
+        ItemStack[] toOutput = new ItemStack[] { new ItemStack(HTGRMaterials.aHTGR_Materials, burnedballs, meta),
                 new ItemStack(HTGRMaterials.aHTGR_Materials, toReduce, meta + 1) };
+        if (!canOutputAll(toOutput)) return false;
+
+        this.mOutputItems = toOutput;
 
         // this.updateSlots(); // not needed ?
 
@@ -454,6 +457,11 @@ public class GT_TileEntity_HTGR extends GT_MetaTileEntity_EnhancedMultiBlockBase
         GT_Utility.sendChatToPlayer(
                 aPlayer,
                 "HTGR is now running in " + (this.empty ? "emptying mode." : "normal Operation"));
+    }
+
+    @Override
+    public boolean supportsVoidProtection() {
+        return true;
     }
 
     public static class HTGRMaterials {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_THTR.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_THTR.java
@@ -254,7 +254,7 @@ public class GT_TileEntity_THTR extends GT_MetaTileEntity_EnhancedMultiBlockBase
 
         int toReduce = MathUtils.floorInt((double) this.fuelsupply * 0.005D * eff);
 
-        this.fuelsupply -= toReduce;
+        final int originalToReduce = toReduce;
         int burnedballs = toReduce / 64;
         if (burnedballs > 0) toReduce -= burnedballs * 64;
 
@@ -264,6 +264,7 @@ public class GT_TileEntity_THTR extends GT_MetaTileEntity_EnhancedMultiBlockBase
                 new ItemStack(THTRMaterials.aTHTR_Materials, toReduce, meta + 1) };
         if (!canOutputAll(toOutput)) return false;
 
+        this.fuelsupply -= originalToReduce;
         this.mOutputItems = toOutput;
 
         // this.updateSlots(); not needed ?

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_THTR.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_THTR.java
@@ -260,8 +260,11 @@ public class GT_TileEntity_THTR extends GT_MetaTileEntity_EnhancedMultiBlockBase
 
         int meta = THTRMaterials.MATERIAL_USED_FUEL_INDEX;
 
-        this.mOutputItems = new ItemStack[] { new ItemStack(THTRMaterials.aTHTR_Materials, burnedballs, meta),
+        ItemStack[] toOutput = new ItemStack[] { new ItemStack(THTRMaterials.aTHTR_Materials, burnedballs, meta),
                 new ItemStack(THTRMaterials.aTHTR_Materials, toReduce, meta + 1) };
+        if (!canOutputAll(toOutput)) return false;
+
+        this.mOutputItems = toOutput;
 
         // this.updateSlots(); not needed ?
 
@@ -381,6 +384,11 @@ public class GT_TileEntity_THTR extends GT_MetaTileEntity_EnhancedMultiBlockBase
         GT_Utility.sendChatToPlayer(
                 aPlayer,
                 "THTR is now running in " + (this.empty ? "emptying mode." : "normal Operation"));
+    }
+
+    @Override
+    public boolean supportsVoidProtection() {
+        return true;
     }
 
     public static class THTRMaterials {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -545,12 +545,12 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
     }
 
     @Override
-    public boolean isInputSeparationButtonEnabled() {
+    public boolean supportsInputSeparation() {
         return true;
     }
 
     @Override
-    public boolean isBatchModeButtonEnabled() {
+    public boolean supportsBatchMode() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -545,12 +545,12 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
     }
 
     @Override
-    protected boolean isInputSeparationButtonEnabled() {
+    public boolean isInputSeparationButtonEnabled() {
         return true;
     }
 
     @Override
-    protected boolean isBatchModeButtonEnabled() {
+    public boolean isBatchModeButtonEnabled() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -317,7 +317,7 @@ public class GT_TileEntity_MegaChemicalReactor
     }
 
     @Override
-    public boolean isBatchModeButtonEnabled() {
+    public boolean supportsBatchMode() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -317,7 +317,7 @@ public class GT_TileEntity_MegaChemicalReactor
     }
 
     @Override
-    protected boolean isBatchModeButtonEnabled() {
+    public boolean isBatchModeButtonEnabled() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
@@ -496,7 +496,7 @@ public class GT_TileEntity_MegaDistillTower extends GT_TileEntity_MegaMultiBlock
     }
 
     @Override
-    protected boolean isBatchModeButtonEnabled() {
+    public boolean isBatchModeButtonEnabled() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
@@ -496,7 +496,7 @@ public class GT_TileEntity_MegaDistillTower extends GT_TileEntity_MegaMultiBlock
     }
 
     @Override
-    public boolean isBatchModeButtonEnabled() {
+    public boolean supportsBatchMode() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
@@ -332,7 +332,7 @@ public class GT_TileEntity_MegaVacuumFreezer extends GT_TileEntity_MegaMultiBloc
     }
 
     @Override
-    public boolean isBatchModeButtonEnabled() {
+    public boolean supportsBatchMode() {
         return true;
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
@@ -332,7 +332,7 @@ public class GT_TileEntity_MegaVacuumFreezer extends GT_TileEntity_MegaMultiBloc
     }
 
     @Override
-    protected boolean isBatchModeButtonEnabled() {
+    public boolean isBatchModeButtonEnabled() {
         return true;
     }
 }


### PR DESCRIPTION
Requires https://github.com/GTNewHorizons/GT5-Unofficial/pull/2024
`GT_TileEntity_DEHP`, `GT_TileEntity_VoidMiner_Base`, `GT_TileEntity_Windmill` and mega multis are still untouched