### PR TITLE
Buff Output of Oganesson Fusion Recipe by 5x

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/processingLoaders/AdditionalRecipes.java
@@ -366,8 +366,8 @@ public class AdditionalRecipes {
                 480000000);
         GT_Values.RA.addFusionReactorRecipe(
                 WerkstoffLoader.Californium.getMolten(32),
-                WerkstoffLoader.Calcium.getMolten(144),
-                WerkstoffLoader.Oganesson.getFluidOrGas(144),
+                WerkstoffLoader.Calcium.getMolten(720),
+                WerkstoffLoader.Oganesson.getFluidOrGas(720),
                 420,
                 49152,
                 600000000);


### PR DESCRIPTION
This PR is meant to work alongside the EBF noble gas changes that are upcoming. Until then, this will be a draft PR.

The purpose of this change is to reduce the amount of mk3 Fusion Reactors needed to upkeep a MBF that uses Oganesson to reduce recipe times. The upcoming noble gas changes will make it worth using in EBF crafting, and the planned new numbers will make it so a MBF processing Neutronium, with all parallels and no overclocks, will need 18 mk3 reactors. Since that's too many expensive reactors, this change makes it so only 4 reactors are needed, approximately one per 64 parallels, which was a suggestion given by LewisSaber.

Additionally, this buff will help with Oganesson usage in other recipes, and it will bring the fusion recipe closer to the replication recipe, which is better but is meant to be deprecated, alongside other replication recipes in general.