### PR TITLE
Ebf Noble Gas Overhaul

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -86,6 +86,7 @@ public class StaticRecipeChangeLoaders {
             gtEbfGasRecipeTimeMultipliers = new TObjectDoubleHashMap<>(10, 0.5F, -1.0D); // keep default value as -1
             // Example to make Argon cut recipe times into a third of the original:
             // gtEbfGasRecipeTimeMultipliers.put(Materials.Argon, 1.0D / 3.0D);
+            gtEbfGasRecipeTimeMultipliers.put(Materials.Argon, 0.54687D);
         }
         if (gtEbfGasRecipeConsumptionMultipliers == null) {
             // For Werkstoff gases, use Werkstoff.Stats.setEbfGasRecipeConsumedAmountMultiplier

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -86,7 +86,10 @@ public class StaticRecipeChangeLoaders {
             gtEbfGasRecipeTimeMultipliers = new TObjectDoubleHashMap<>(10, 0.5F, -1.0D); // keep default value as -1
             // Example to make Argon cut recipe times into a third of the original:
             // gtEbfGasRecipeTimeMultipliers.put(Materials.Argon, 1.0D / 3.0D);
-            gtEbfGasRecipeTimeMultipliers.put(Materials.Argon, 0.54687D);
+
+            gtEbfGasRecipeTimeMultipliers.put(Materials.Helium, 0.9D);
+            gtEbfGasRecipeTimeMultipliers.put(Materials.Argon, 0.8D);
+            gtEbfGasRecipeTimeMultipliers.put(Materials.Radon, 0.7D);
         }
         if (gtEbfGasRecipeConsumptionMultipliers == null) {
             // For Werkstoff gases, use Werkstoff.Stats.setEbfGasRecipeConsumedAmountMultiplier
@@ -95,6 +98,9 @@ public class StaticRecipeChangeLoaders {
             // Example to make Argon recipes use half the gas amount of the primary recipe (1000L->500L, 2000L->1000L
             // etc.):
             // gtEbfGasRecipeConsumptionMultipliers.put(Materials.Argon, 1.0D / 2.0D);
+            gtEbfGasRecipeConsumptionMultipliers.put(Materials.Helium, 1.0D);
+            gtEbfGasRecipeConsumptionMultipliers.put(Materials.Argon, 0.85D);
+            gtEbfGasRecipeConsumptionMultipliers.put(Materials.Radon, 0.7D);
         }
         ArrayListMultimap<SubTag, GT_Recipe> toChange = getRecipesToChange(NOBLE_GAS, ANAEROBE_GAS);
         editRecipes(toChange, getNoGasItems(toChange));

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/StaticRecipeChangeLoaders.java
@@ -87,6 +87,7 @@ public class StaticRecipeChangeLoaders {
             // Example to make Argon cut recipe times into a third of the original:
             // gtEbfGasRecipeTimeMultipliers.put(Materials.Argon, 1.0D / 3.0D);
 
+            gtEbfGasRecipeTimeMultipliers.put(Materials.Nitrogen, 1.0D);
             gtEbfGasRecipeTimeMultipliers.put(Materials.Helium, 0.9D);
             gtEbfGasRecipeTimeMultipliers.put(Materials.Argon, 0.8D);
             gtEbfGasRecipeTimeMultipliers.put(Materials.Radon, 0.7D);
@@ -98,6 +99,7 @@ public class StaticRecipeChangeLoaders {
             // Example to make Argon recipes use half the gas amount of the primary recipe (1000L->500L, 2000L->1000L
             // etc.):
             // gtEbfGasRecipeConsumptionMultipliers.put(Materials.Argon, 1.0D / 2.0D);
+            gtEbfGasRecipeConsumptionMultipliers.put(Materials.Nitrogen, 1.0D);
             gtEbfGasRecipeConsumptionMultipliers.put(Materials.Helium, 1.0D);
             gtEbfGasRecipeConsumptionMultipliers.put(Materials.Argon, 0.85D);
             gtEbfGasRecipeConsumptionMultipliers.put(Materials.Radon, 0.7D);
@@ -406,22 +408,24 @@ public class StaticRecipeChangeLoaders {
 
     private static int transformEBFGasRecipeTime(GT_Recipe recipe, Materials originalGas, Materials newGas) {
         double newEbfMul = gtEbfGasRecipeTimeMultipliers.get(newGas);
-        if (newEbfMul < 0.0D) {
+        double originalEbfMul = gtEbfGasRecipeTimeMultipliers.get(originalGas);
+        if (newEbfMul < 0.0D || originalEbfMul < 0.0D) {
             return transformEBFGasRecipeTime(recipe.mDuration, originalGas.getProtons(), newGas.getProtons());
         } else {
-            return Math.max(1, (int) ((double) recipe.mDuration * newEbfMul));
+            return Math.max(1, (int) ((double) recipe.mDuration * newEbfMul / originalEbfMul));
         }
     }
 
     private static int transformEBFGasRecipeTime(GT_Recipe recipe, Materials originalGas, Werkstoff newGas) {
         double newEbfMul = newGas.getStats().getEbfGasRecipeTimeMultiplier();
-        if (newEbfMul < 0.0D) {
+        double originalEbfMul = gtEbfGasRecipeTimeMultipliers.get(originalGas);
+        if (newEbfMul < 0.0D || originalEbfMul < 0.0D) {
             return transformEBFGasRecipeTime(
                     recipe.mDuration,
                     originalGas.getProtons(),
                     newGas.getStats().getProtons());
         } else {
-            return Math.max(1, (int) ((double) recipe.mDuration * newEbfMul));
+            return Math.max(1, (int) ((double) recipe.mDuration * newEbfMul / originalEbfMul));
         }
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
@@ -643,7 +643,7 @@ public class WerkstoffLoader {
             new short[] { 0x14, 0x39, 0x7F, 0 },
             "Oganesson",
             "Og",
-            new Werkstoff.Stats().setProtons(118).setMass(294).setGas(true),
+            new Werkstoff.Stats().setProtons(118).setMass(294).setGas(true).setEbfGasRecipeTimeMultiplier(0.2d),
             Werkstoff.Types.ELEMENT,
             new Werkstoff.GenerationFeatures().disable().addCells(),
             38,

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/WerkstoffLoader.java
@@ -631,7 +631,8 @@ public class WerkstoffLoader {
             new short[] { 0x14, 0x39, 0x7F, 0 },
             "Xenon",
             "Xe",
-            new Werkstoff.Stats().setProtons(54).setMass(131).setGas(true),
+            new Werkstoff.Stats().setProtons(54).setMass(131).setGas(true).setEbfGasRecipeTimeMultiplier(0.4d)
+                    .setEbfGasRecipeConsumedAmountMultiplier(0.25d),
             Werkstoff.Types.ELEMENT,
             new Werkstoff.GenerationFeatures().disable().addCells().enforceUnification(),
             37,
@@ -643,7 +644,8 @@ public class WerkstoffLoader {
             new short[] { 0x14, 0x39, 0x7F, 0 },
             "Oganesson",
             "Og",
-            new Werkstoff.Stats().setProtons(118).setMass(294).setGas(true).setEbfGasRecipeTimeMultiplier(0.2d),
+            new Werkstoff.Stats().setProtons(118).setMass(294).setGas(true).setEbfGasRecipeTimeMultiplier(0.3d)
+                    .setEbfGasRecipeConsumedAmountMultiplier(0.1d),
             Werkstoff.Types.ELEMENT,
             new Werkstoff.GenerationFeatures().disable().addCells(),
             38,
@@ -679,7 +681,8 @@ public class WerkstoffLoader {
             new short[] { 0xff, 0x07, 0x3a },
             "Neon",
             "Ne",
-            new Werkstoff.Stats().setProtons(Element.Ne.mProtons).setMass(Element.Ne.getMass()).setGas(true),
+            new Werkstoff.Stats().setProtons(Element.Ne.mProtons).setMass(Element.Ne.getMass()).setGas(true)
+                    .setEbfGasRecipeTimeMultiplier(0.6d).setEbfGasRecipeConsumedAmountMultiplier(0.55d),
             Werkstoff.Types.ELEMENT,
             new Werkstoff.GenerationFeatures().disable().addCells().enforceUnification(),
             41,
@@ -691,7 +694,8 @@ public class WerkstoffLoader {
             new short[] { 0xb1, 0xff, 0x32 },
             "Krypton",
             "Kr",
-            new Werkstoff.Stats().setProtons(Element.Kr.mProtons).setMass(Element.Kr.getMass()).setGas(true),
+            new Werkstoff.Stats().setProtons(Element.Kr.mProtons).setMass(Element.Kr.getMass()).setGas(true)
+                    .setEbfGasRecipeTimeMultiplier(0.5d).setEbfGasRecipeConsumedAmountMultiplier(0.4d),
             Werkstoff.Types.ELEMENT,
             new Werkstoff.GenerationFeatures().disable().addCells().enforceUnification(),
             42,


### PR DESCRIPTION
This is a fairly important overhaul. It is possible that a few followup PRs for specific recipes will be needed but most should be covered in the accompanying coremod PR.

### Goals:
- Make more noble gases useful for EBF smelting. Not just Radon (and maybe some Argon) as currently.
- Make it possible to reach better time and power reductions in UHV and UEV in particular. This goes very well with the otherwise unrelated changes to fusion power that make such reductions more desirable.
- Ensure that there isn't a single noble gas that is the most suitable for almost all situations.

### Method:
- Higher tier gases are consumed in a lower amount than 1000L. Down to 100L at Og. (there are also plans to improve fusion recipes for oganesson further. https://github.com/GTNewHorizons/bartworks/pull/335)
- A complete new formula for the smelting time reduction (see details below). Radon should give similar results as before, but Neon, Krypton, Xenon, and Oganesson are now stronger.

### Details and Reasons:
Gas Usage:
![image](https://github.com/GTNewHorizons/bartworks/assets/40274384/0eb3c3aa-d025-42c4-b43c-af2c73c2900c)
Relative Smelting Time modifiers:
![image](https://github.com/GTNewHorizons/bartworks/assets/40274384/7efe3f93-309e-49fb-8226-bad260da1462)

As before the gas usage is once per recipe, just a smaller amount for better gases. The relative time modifier is best explained by how a recipe is defined: Among the other parts (input/output/heat/voltage) it is defined with a input fluid and a recipe time. This specific gas recipe will appear in the game exactly with the time defined (though with adjusted gas amount). All others are then calculated relative to it.
E.g., Lets say I define the recipe with 350s and radon. then the Krypton recipe will take 350s/0.7*0.5=250s.

This is very similar to how the current recipes are generated except that we know use sane and easy to understand multipliers. These multipliers can also be easily adjusted for balancing reasons in the future.

One annoyance is that currently not all recipes are defined based on the same gas. E.g., some are define with argon and some with radon. As the ratios between the gas multipliers change, different recipes will change differently. To resolve that there is a accompanying coremod PR to base all recipes there on radon (with the old times). This should ensure that most import radon smelting times are very similar to the old. (https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/644)

### Example values for smelting times:
Keep in mind that there are gas reductions on top. This is in combination with the coremod PR. Further reductions like OCs or Volcanus bonus are not included.
All in seconds:
![image](https://github.com/GTNewHorizons/bartworks/assets/40274384/f6460219-31e4-4165-8c7f-c65eab4870be)

I should also add that recipes like early recipes like nichrome dust+ nitrogen, titanium dust+ nitrogen, tungstensteel dust +nitrogen, etc, are all the same as before.