### PR TITLE
Use the right LuV material for CAL

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/recipes/AssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/recipes/AssemblyLine.java
@@ -12,7 +12,11 @@ import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import com.github.bartimaeusnek.bartworks.util.BW_Util;
 
-import gregtech.api.enums.*;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_OreDictUnificator;
 
 public class AssemblyLine implements Runnable {
@@ -58,7 +62,8 @@ public class AssemblyLine implements Runnable {
                 24000,
                 new ItemStack[] { ItemList.Machine_LuV_CircuitAssembler.get(1L), ItemList.Robot_Arm_LuV.get(4L),
                         ItemList.Electric_Motor_LuV.get(4L), ItemList.Field_Generator_LuV.get(1L),
-                        ItemList.Emitter_LuV.get(1L), ItemList.Sensor_LuV.get(1L), Materials.Chrome.getPlates(8) },
+                        ItemList.Emitter_LuV.get(1L), ItemList.Sensor_LuV.get(1L),
+                        WerkstoffLoader.LuVTierMaterial.get(OrePrefixes.plate, 8) },
                 new FluidStack[] { new FluidStack(solderIndalloy, 1440) },
                 ItemRegistry.cal.copy(),
                 24000,

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/recipes/CraftingRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/recipes/CraftingRecipes.java
@@ -404,7 +404,7 @@ public class CraftingRecipes implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.wireGt04, Materials.Naquadah, 1L), 'C',
                         "circuit" + Materials.Master, 'F', ItemList.Field_Generator_LuV.get(1L), 'E',
                         ItemList.Emitter_LuV.get(1L), 'S', ItemList.Sensor_LuV.get(1L), 'P',
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Chrome, 1L), });
+                        WerkstoffLoader.LuVTierMaterial.get(OrePrefixes.plate, 1), });
 
         // ClonalCellularSynthesisModule
         GT_ModHandler.addCraftingRecipe(
@@ -414,7 +414,7 @@ public class CraftingRecipes implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.wireGt04, Materials.Naquadah, 1L), 'C',
                         "circuit" + Materials.Master, 'F', ItemList.Field_Generator_LuV.get(1L), 'E',
                         ItemList.Emitter_LuV.get(1L), 'S', ItemList.Sensor_LuV.get(1L), 'P',
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Chrome, 1L), });
+                        WerkstoffLoader.LuVTierMaterial.get(OrePrefixes.plate, 1), });
 
         GT_ModHandler.addCraftingRecipe(
                 new GT_TileEntity_BioVat(


### PR DESCRIPTION
Follow up to https://github.com/GTNewHorizons/bartworks/pull/320.
Somehow I didnt realize bartworks was also hacking its own recipes.

This returns CAL recipe to rhodium-plated palladium.

I also change the material from chrome to rhodium-plated palladium for the Clonal Cellular Synthesis Module and the Transformation Module as the are all LuV recipes outside of that. (even though these were missed by the hacky replacements in the past)

Might be the fix to https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13757.