### PR TITLE
Plutonium fix

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_GT_MaterialReference.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/BW_GT_MaterialReference.java
@@ -67,7 +67,6 @@ public class BW_GT_MaterialReference {
     public static Werkstoff Palladium = new Werkstoff(Materials.Palladium, ADD_CASINGS_ONLY, ELEMENT, 31_766 + 52);
     public static Werkstoff Phosphorus = new Werkstoff(Materials.Phosphorus, ADD_CASINGS_ONLY, ELEMENT, 31_766 + 21);
     public static Werkstoff Platinum = new Werkstoff(Materials.Platinum, ADD_CASINGS_ONLY, ELEMENT, 31_766 + 85);
-    public static Werkstoff Plutonium = new Werkstoff(Materials.Plutonium, ADD_CASINGS_ONLY, ELEMENT, 31_766 + 100);
     public static Werkstoff Plutonium241 = new Werkstoff(
             Materials.Plutonium241,
             ADD_CASINGS_ONLY,


### PR DESCRIPTION
Together with https://github.com/GTNewHorizons/GTplusplus/pull/698 this fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13748

We don't need a plutonium werkstoff and werkstoff based gt material for it (the bridgematerial), they just break things. In this case the replicator. My best guess is that it gets the name wrong (plutonium->plutonium239) which then breaks stuff.

It also does not provide us with anything useful in return (casings are generated anyway). In fact we can probably clean up 90% of this class. But for now just this smaller cleanup for Plutonium only; to fix the replicator recipe.