### PR TITLE
Change Infinity to Neutronium in alternate High Density recipes

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
@@ -73,7 +73,7 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
         addElectricImplosionRecipe(
                 // IN.
                 new ItemStack[] { getModItem(GoodGenerator.ID, "highDensityPlutoniumNugget", 5L) },
-                new FluidStack[] { Materials.Infinity.getMolten(9L) },
+                new FluidStack[] { Materials.Neutronium.getMolten(72L) },
                 // OUT.
                 new ItemStack[] { getModItem(GoodGenerator.ID, "highDensityPlutonium", 1L) },
                 new FluidStack[] { GT_Values.NF },
@@ -84,7 +84,7 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
         addElectricImplosionRecipe(
                 // IN.
                 new ItemStack[] { getModItem(GoodGenerator.ID, "highDensityUraniumNugget", 5L) },
-                new FluidStack[] { Materials.Infinity.getMolten(9L) },
+                new FluidStack[] { Materials.Neutronium.getMolten(72L) },
                 // OUT.
                 new ItemStack[] { getModItem(GoodGenerator.ID, "highDensityUranium", 1L) },
                 new FluidStack[] { GT_Values.NF },
@@ -95,7 +95,7 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
         addElectricImplosionRecipe(
                 // IN.
                 new ItemStack[] { getModItem(GoodGenerator.ID, "highDensityThoriumNugget", 5L) },
-                new FluidStack[] { Materials.Infinity.getMolten(9L) },
+                new FluidStack[] { Materials.Neutronium.getMolten(72L) },
                 // OUT.
                 new ItemStack[] { getModItem(GoodGenerator.ID, "highDensityThorium", 1L) },
                 new FluidStack[] { GT_Values.NF },


### PR DESCRIPTION
See https://github.com/GTNewHorizons/GoodGenerator/pull/198 for related naqfuel Buffs.

Changes the Molten Infinity to Molten Neutronium (9L -> 72L): Essentially allows you to replace 8 wrapped ingots for 1 neutronium, which is hard to sustain pre-DTPF.

Infinity is extremely energy intensive and required in large amounts, with no real way of making it cheap; It is much easier to just mine more uranium, plutonium, graphite and thorium than it is to use infinity. Changing this to neutronium makes the improved recipes actually viable after the player acquires the DTPF for making neutronium, allowing easier scaling of Naqfuel in UIV+.