### PR TITLE
Make the Humongous input hatch UXV tier

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_HumongousInputHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_HumongousInputHatch.java
@@ -21,7 +21,7 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Input
 public class GT_MetaTileEntity_HumongousInputHatch extends GT_MetaTileEntity_Hatch_Input {
 
     public GT_MetaTileEntity_HumongousInputHatch(int aID, String aName, String aNameRegional) {
-        super(aID, aName, aNameRegional, 0);
+        super(aID, aName, aNameRegional, 13);
         this.mDescriptionArray[1] = "Capacity: 2,000,000,000L";
     }
 


### PR DESCRIPTION
This PR makes the humongous input hatch a uxv tier hatch so machines can recognize it as such. This should also allow its usage on fusion reactors. 
It also makes the hatch look tier appropriate.
![image](https://github.com/GTNewHorizons/bartworks/assets/93287602/36685411-d56c-41b1-8b84-edc97b83bd04)
