### PR TITLE
Relax the Mega Chemical Reactor Structure Requirements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1696265388
+//version: 1697697256
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -793,12 +793,12 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.5.0'
+    def lwjgl3ifyVersion = '1.5.1'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.7')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.17')
     }
 
     java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches") {transitive = false}

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -198,8 +198,13 @@ public class GT_TileEntity_MegaChemicalReactor
             .addElement('r', Maintenance.newAny(CASING_INDEX, 2))
             .addElement(
                     'e',
-                    buildHatchAdder(GT_TileEntity_MegaChemicalReactor.class).atLeast(Energy.or(ExoticEnergy))
-                            .casingIndex(CASING_INDEX).dot(3).buildAndChain(GregTech_API.sBlockCasings8, 0))
+                    ofChain(
+                            ofBlock(GregTech_API.sBlockCasings8, 0),
+                            buildHatchAdder(GT_TileEntity_MegaChemicalReactor.class)
+                                    .anyOf(InputBus, InputHatch, OutputBus, OutputHatch).casingIndex(CASING_INDEX)
+                                    .dot(3).build(),
+                            buildHatchAdder(GT_TileEntity_MegaChemicalReactor.class).atLeast(Energy.or(ExoticEnergy))
+                                    .casingIndex(CASING_INDEX).dot(3).build()))
             .addElement('c', ofChain(ofBlock(GregTech_API.sBlockCasings4, 7), ofBlock(GregTech_API.sBlockCasings5, 13)))
             .addElement(
                     'g',

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -198,13 +198,9 @@ public class GT_TileEntity_MegaChemicalReactor
             .addElement('r', Maintenance.newAny(CASING_INDEX, 2))
             .addElement(
                     'e',
-                    ofChain(
-                            ofBlock(GregTech_API.sBlockCasings8, 0),
-                            buildHatchAdder(GT_TileEntity_MegaChemicalReactor.class)
-                                    .anyOf(InputBus, InputHatch, OutputBus, OutputHatch).casingIndex(CASING_INDEX)
-                                    .dot(3).build(),
-                            buildHatchAdder(GT_TileEntity_MegaChemicalReactor.class).atLeast(Energy.or(ExoticEnergy))
-                                    .casingIndex(CASING_INDEX).dot(3).build()))
+                    buildHatchAdder(GT_TileEntity_MegaChemicalReactor.class)
+                            .atLeast(Energy.or(ExoticEnergy), InputHatch, InputBus, OutputHatch, OutputBus)
+                            .casingIndex(CASING_INDEX).dot(3).buildAndChain(GregTech_API.sBlockCasings8, 0))
             .addElement('c', ofChain(ofBlock(GregTech_API.sBlockCasings4, 7), ofBlock(GregTech_API.sBlockCasings5, 13)))
             .addElement(
                     'g',


### PR DESCRIPTION
This PR relaxes the Mega Chemical Reactor Structure Requirements to allow I/O hatches on the back of the structure, in the (almost) 3x3 where currently only the energy hatch is allowed.

This is my first time working with StructureLib, let me know if there is a better way to accomplish this.