### PR TITLE
Fix MDT void protection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1697697256
+//version: 1699290261
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -646,7 +646,7 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.7.1"
+def mixinProviderVersion = "0.1.13"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
 ext.mixinProviderSpec = mixinProviderSpec
@@ -1187,9 +1187,8 @@ publishing {
             version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
         }
     }
-
     repositories {
-        if (usesMavenPublishing.toBoolean()) {
+        if (usesMavenPublishing.toBoolean() && System.getenv("MAVEN_USER") != null) {
             maven {
                 url = mavenPublishUrl
                 allowInsecureProtocol = mavenPublishUrl.startsWith("http://") // Mostly for the GTNH maven

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
@@ -56,6 +56,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
+import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_Output_ME;
 
 public class GT_TileEntity_MegaDistillTower extends GT_TileEntity_MegaMultiBlockBase<GT_TileEntity_MegaDistillTower>
         implements ISurvivalConstructable {
@@ -374,6 +375,32 @@ public class GT_TileEntity_MegaDistillTower extends GT_TileEntity_MegaMultiBlock
     @Override
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic().setMaxParallel(ConfigHandler.megaMachinesMax);
+    }
+
+    @Override
+    public boolean canDumpFluidToME() {
+        int tHatchCount = 0;
+
+        for (List<GT_MetaTileEntity_Hatch_Output> tLayerOutputHatches : this.mOutputHatchesByLayer) {
+
+            boolean tHatchFound = false;
+
+            for (IFluidStore tHatch : tLayerOutputHatches) {
+                if (tHatch instanceof GT_MetaTileEntity_Hatch_Output_ME) {
+                    tHatchCount++;
+                    tHatchFound = true;
+                    break;
+                }
+            }
+
+            // Early exit if we didn't find a valid hatch on this layer.
+            if (!tHatchFound) {
+                break;
+            }
+        }
+
+        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
+        return tHatchCount == this.mOutputHatchesByLayer.size();
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
@@ -379,28 +379,26 @@ public class GT_TileEntity_MegaDistillTower extends GT_TileEntity_MegaMultiBlock
 
     @Override
     public boolean canDumpFluidToME() {
-        int tHatchCount = 0;
 
+        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
         for (List<GT_MetaTileEntity_Hatch_Output> tLayerOutputHatches : this.mOutputHatchesByLayer) {
 
-            boolean tHatchFound = false;
+            boolean foundMEHatch = false;
 
             for (IFluidStore tHatch : tLayerOutputHatches) {
                 if (tHatch instanceof GT_MetaTileEntity_Hatch_Output_ME) {
-                    tHatchCount++;
-                    tHatchFound = true;
+                    foundMEHatch = true;
                     break;
                 }
             }
 
-            // Early exit if we didn't find a valid hatch on this layer.
-            if (!tHatchFound) {
-                break;
+            // Exit if we didn't find a valid hatch on this layer.
+            if (!foundMEHatch) {
+                return false;
             }
         }
 
-        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
-        return tHatchCount == this.mOutputHatchesByLayer.size();
+        return true;
     }
 
     @Override


### PR DESCRIPTION
I've noticed that two MDTs (Mega Distillation Tower) had a fairly high tick time in my world. After a quick inspection it seemed to one tick despite batch mode being enabled. After a quick check it turned out that disabling void protection helped and multi didn't actually void anything (as it was connected to ME output hatch). 

I had a similar setup for MVF (Mega Vacuum Freezer) that worked correctly so MDT seemed to be the problem.

What is happening is that MDT has special logic to output per layer, original code was not detecting any hatches so it would throttle production.

I've changed this logic to detect ME Output Hatch per layer, and if all layers have a hatch then assume this multi does not need to go through full void protection pass.