### PR TITLE
Remove messages for old ASM

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/ASM/BWCore.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/ASM/BWCore.java
@@ -58,14 +58,10 @@ public class BWCore extends DummyModContainer {
     public void preInit(FMLPreInitializationEvent event) {
         shouldTransform[0] = ConfigHandler.enabledPatches[0];
         shouldTransform[1] = ConfigHandler.enabledPatches[1];
+        shouldTransform[2] = ConfigHandler.enabledPatches[2];
         shouldTransform[3] = ConfigHandler.enabledPatches[3];
-        shouldTransform[4] = false;
-        shouldTransform[5] = ConfigHandler.enabledPatches[5];
-        shouldTransform[6] = ConfigHandler.enabledPatches[6];
-        // shouldTransform[6] = true;
-        BWCore.BWCORE_LOG.info("Extra Utilities found and ASM Patch enabled? " + shouldTransform[0]);
-        BWCore.BWCORE_LOG.info("Thaumcraft found and ASM Patch enabled? " + shouldTransform[3]);
-        BWCore.BWCORE_LOG.info("RWG found and ASM Patch enabled? " + shouldTransform[5]);
+        BWCore.BWCORE_LOG.debug("Extra Utilities found and ASM Patch enabled? " + shouldTransform[0]);
+        BWCore.BWCORE_LOG.debug("Thaumcraft found and ASM Patch enabled? " + shouldTransform[2]);
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/ASM/BWCore.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/ASM/BWCore.java
@@ -60,8 +60,8 @@ public class BWCore extends DummyModContainer {
         shouldTransform[1] = ConfigHandler.enabledPatches[1];
         shouldTransform[2] = ConfigHandler.enabledPatches[2];
         shouldTransform[3] = ConfigHandler.enabledPatches[3];
-        BWCore.BWCORE_LOG.debug("Extra Utilities found and ASM Patch enabled? " + shouldTransform[0]);
-        BWCore.BWCORE_LOG.debug("Thaumcraft found and ASM Patch enabled? " + shouldTransform[2]);
+        BWCore.BWCORE_LOG.info("Extra Utilities found and ASM Patch enabled? " + shouldTransform[0]);
+        BWCore.BWCORE_LOG.info("Thaumcraft found and ASM Patch enabled? " + shouldTransform[2]);
     }
 
     @Override


### PR DESCRIPTION
It doesn't affect them being applied, but clean the logs a bit.

This could likely be entirely refactored, it's a strange way to do it.