### PR TITLE
Fix CAL Locking itself

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -238,7 +238,8 @@ public class GT_TileEntity_CircuitAssemblyLine extends
     public void loadNBTData(NBTTagCompound aNBT) {
         this.type = aNBT.getCompoundTag(IMPRINT_KEY);
         this.imprintedItemName = GT_LanguageManager
-                .getTranslateableItemStackName(ItemStack.loadItemStackFromNBT(this.type));
+        this.imprintedItemName = this.type == null ? ""
+                : GT_LanguageManager.getTranslateableItemStackName(ItemStack.loadItemStackFromNBT(this.type));
         mode = aNBT.getInteger(RUNNING_MODE_KEY);
         length = aNBT.getInteger(LENGTH_KEY);
         super.loadNBTData(aNBT);

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -562,7 +562,7 @@ public class GT_TileEntity_CircuitAssemblyLine extends
 
     @Override
     public boolean isRecipeLockingEnabled() {
-        return this.imprintedItemName != null && !"".equals(this.imprintedItemName);
+        return this.mode == 0 && this.imprintedItemName != null && !"".equals(this.imprintedItemName);
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -237,7 +237,6 @@ public class GT_TileEntity_CircuitAssemblyLine extends
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         this.type = aNBT.getCompoundTag(IMPRINT_KEY);
-        this.imprintedItemName = GT_LanguageManager
         this.imprintedItemName = this.type == null ? ""
                 : GT_LanguageManager.getTranslateableItemStackName(ItemStack.loadItemStackFromNBT(this.type));
         mode = aNBT.getInteger(RUNNING_MODE_KEY);


### PR DESCRIPTION
Basically makes CAL not lock itself on 1 recipe in CA mode, huge thanks to **chaos_filler** for finding a way to consistenly replicate issue, issue was due to someone(check:https://discord.com/channels/181078474394566657/939305179524792340/1186963175808188506) returning null as string, but it will still lock itself on one recipe if it was imprinted and switched to CA mode
This should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15072