### PR TITLE
Fix painted low power laser converter explosion

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/crossmod/tectech/tileentites/tiered/TT_Abstract_LowPowerLaserThingy.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/tectech/tileentites/tiered/TT_Abstract_LowPowerLaserThingy.java
@@ -98,7 +98,9 @@ public abstract class TT_Abstract_LowPowerLaserThingy extends GT_MetaTileEntity_
 
     @Override
     public void loadNBTData(NBTTagCompound nbtTagCompound) {
-        Optional.ofNullable(nbtTagCompound).ifPresent(tag -> this.AMPERES = tag.getLong("AMPERES"));
+        if (nbtTagCompound != null && nbtTagCompound.hasKey("AMPERES")) {
+            this.AMPERES = nbtTagCompound.getLong("AMPERES");
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes issue described in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13899

After you paint low power laser converter, pickup and place back in the world, it was losing `AMPERES` data.
`loadNBTData` method was trying to read "AMPERES" from an NBT tag containing only information about color.
This adds a check so if there is no "AMPERES" in the NBT tag, it would not overwrite it with default value.