### PR TITLE
Add EIC recipes for a few Singularities & Infinity Catalyst

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,6 @@ dependencies {
     api("com.github.GTNewHorizons:Avaritia:1.49:dev")
     implementation("com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev")
 
-    compileOnly("com.github.GTNewHorizons:TGregworks:GTNH-1.0.27:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:TinkersGregworks:GTNH-1.0.27:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.6-GTNH:api") {transitive = false}
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,6 @@ dependencies {
     api("com.github.GTNewHorizons:Avaritia:1.49:dev")
     implementation("com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev")
 
-    compileOnly("TGregworks:TGregworks-1.7.10-GTNH-1.0.25-deobf") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:TGregworks:GTNH-1.0.27:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.6-GTNH:api") {transitive = false}
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,6 @@ dependencies {
     api("com.github.GTNewHorizons:Avaritia:1.49:dev")
     implementation("com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev")
 
-    compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.24:deobf") {transitive = false}
+    compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.24-pre:deobf") {transitive = false}
     compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.6-GTNH:api") {transitive = false}
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,6 @@ dependencies {
     api("com.github.GTNewHorizons:Avaritia:1.49:dev")
     implementation("com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev")
 
-    compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.24-pre:deobf") {transitive = false}
+    compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.25:deobf") {transitive = false}
     compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.6-GTNH:api") {transitive = false}
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,6 @@ dependencies {
     api("com.github.GTNewHorizons:Avaritia:1.49:dev")
     implementation("com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev")
 
-    compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.25:deobf") {transitive = false}
+    compileOnly("TGregworks:TGregworks-1.7.10-GTNH-1.0.25-deobf") {transitive = false}
     compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.6-GTNH:api") {transitive = false}
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
@@ -1,6 +1,7 @@
 package com.github.bartimaeusnek.bartworks.common.loaders;
 
 import static gregtech.api.enums.GT_Values.M;
+import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.GoodGenerator;
 import static gregtech.api.enums.Mods.OpenComputers;
@@ -122,6 +123,43 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
                 20 * 4,
                 (int) TierEU.RECIPE_UXV);
 
+        // Infinity Catalyst
+        addElectricImplosionRecipe(
+                // IN.
+                new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.dust, Materials.InfinityCatalyst, 64L), },
+                new FluidStack[] { GT_Values.NF },
+                // OUT.
+                new ItemStack[] { getModItem(Avaritia.ID, "Resource", 1L, 5) },
+                new FluidStack[] { GT_Values.NF },
+                // Recipe stats.
+                1 * 1,
+                (int) TierEU.RECIPE_UIV);
+
+        if (UniversalSingularities.isModLoaded()) {
+            // Fluxed Singularity
+            addElectricImplosionRecipe(
+                    // IN.
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.block, Materials.ElectrumFlux, 16L), },
+                    new FluidStack[] { GT_Values.NF },
+                    // OUT.
+                    new ItemStack[] { getModItem(UniversalSingularities.ID, "universal.general.singularity", 1L, 20) },
+                    new FluidStack[] { GT_Values.NF },
+                    // Recipe stats.
+                    1 * 1,
+                    (int) TierEU.RECIPE_UIV);
+
+            // Iron Singularity
+            addElectricImplosionRecipe(
+                    // IN.
+                    new ItemStack[] { GT_Values.NI },
+                    new FluidStack[] { Materials.Iron.getMolten(7296 * 9 * 144L) },
+                    // OUT.
+                    new ItemStack[] { getModItem(Avaritia.ID, "Singularity", 1L, 0) },
+                    new FluidStack[] { GT_Values.NF },
+                    // Recipe stats.
+                    1 * 1,
+                    (int) TierEU.RECIPE_UIV);
+        }
         // MHDCSM V2
         addElectricImplosionRecipe(
                 // IN.


### PR DESCRIPTION
These are required in massive amounts later on, and the only way to make them is using the Neutronium Compressor which is super slow and not parallelizable. They need UIV voltage so you still need to use the compressor initially, but this allows scaling the recipes up later on.

Iron Singularity uses molten iron as the base recipe uses over 7000 blocks of iron.

![image](https://github.com/GTNewHorizons/bartworks/assets/69092953/2c621dfb-29cc-40cd-98ca-00747e5bb21c)
