### PR TITLE
CAL CA mode recipe tier nerf

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import gregtech.api.util.GT_Recipe;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -85,6 +84,7 @@ import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
@@ -172,8 +172,7 @@ public class GT_TileEntity_CircuitAssemblyLine extends
                                 + EnumChatFormatting.GRAY)
                 .addInfo("Recipe tier is hatch tier - 1")
                 .addInfo("This mode supports Crafting Input Buffer/Bus and allows bus separation").addInfo("")
-                .addSeparator()
-                .addInfo(BW_Tooltip_Reference.TT_BLUEPRINT)
+                .addSeparator().addInfo(BW_Tooltip_Reference.TT_BLUEPRINT)
                 .beginVariableStructureBlock(2, 7, 3, 3, 3, 3, false)
                 .addStructureInfo("From Bottom to Top, Left to Right")
                 .addStructureInfo(
@@ -292,7 +291,7 @@ public class GT_TileEntity_CircuitAssemblyLine extends
             @Override
             @Nonnull
             protected CheckRecipeResult validateRecipe(@Nonnull GT_Recipe recipe) {
-                //limit CA mode recipes to hatch tier - 1
+                // limit CA mode recipes to hatch tier - 1
                 if (GT_TileEntity_CircuitAssemblyLine.this.mode == 1
                         && recipe.mEUt > GT_TileEntity_CircuitAssemblyLine.this.getMaxInputVoltage() / 4) {
                     return CheckRecipeResultRegistry.NO_RECIPE;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -170,7 +170,7 @@ public class GT_TileEntity_CircuitAssemblyLine extends
                         "Does Circuit Assembler recipes, Minimum Length: " + EnumChatFormatting.RED
                                 + MINIMUM_CIRCUIT_ASSEMBLER_LENGTH
                                 + EnumChatFormatting.GRAY)
-                .addInfo("Recipe tier is hatch tier - 1")
+                .addInfo("Recipe tier in Circuit Assembler mode is at most Energy Hatch tier - 1.")
                 .addInfo("This mode supports Crafting Input Buffer/Bus and allows bus separation").addInfo("")
                 .addSeparator().addInfo(BW_Tooltip_Reference.TT_BLUEPRINT)
                 .beginVariableStructureBlock(2, 7, 3, 3, 3, 3, false)

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import gregtech.api.util.GT_Recipe;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -79,6 +80,7 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Input
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.recipe.check.CheckRecipeResult;
+import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
@@ -168,8 +170,10 @@ public class GT_TileEntity_CircuitAssemblyLine extends
                         "Does Circuit Assembler recipes, Minimum Length: " + EnumChatFormatting.RED
                                 + MINIMUM_CIRCUIT_ASSEMBLER_LENGTH
                                 + EnumChatFormatting.GRAY)
+                .addInfo("Recipe tier is hatch tier - 1")
                 .addInfo("This mode supports Crafting Input Buffer/Bus and allows bus separation").addInfo("")
-                .addInfo(BW_Tooltip_Reference.TT_BLUEPRINT).addSeparator()
+                .addSeparator()
+                .addInfo(BW_Tooltip_Reference.TT_BLUEPRINT)
                 .beginVariableStructureBlock(2, 7, 3, 3, 3, 3, false)
                 .addStructureInfo("From Bottom to Top, Left to Right")
                 .addStructureInfo(
@@ -283,7 +287,19 @@ public class GT_TileEntity_CircuitAssemblyLine extends
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic().enablePerfectOverclock();
+        return new ProcessingLogic() {
+
+            @Override
+            @Nonnull
+            protected CheckRecipeResult validateRecipe(@Nonnull GT_Recipe recipe) {
+                //limit CA mode recipes to hatch tier - 1
+                if (GT_TileEntity_CircuitAssemblyLine.this.mode == 1
+                        && recipe.mEUt > GT_TileEntity_CircuitAssemblyLine.this.getMaxInputVoltage() / 4) {
+                    return CheckRecipeResultRegistry.NO_RECIPE;
+                }
+                return CheckRecipeResultRegistry.SUCCESSFUL;
+            }
+        }.enablePerfectOverclock();
     }
 
     @NotNull


### PR DESCRIPTION
CAL in CA mode now will only be able to do recipe with tier -1
However overclock is applied(MV recipe with HV hatch gets intended 4x boost)
Chochem please its best I came up with in tooltip at 4 am

reason: Otherwise it can skip ahead which was not the intend of CA mode.