### PR TITLE
Fix a bug in mega distill tower

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaDistillTower.java
@@ -303,6 +303,7 @@ public class GT_TileEntity_MegaDistillTower extends GT_TileEntity_MegaMultiBlock
 
         // validate final invariants...
         return this.mCasing >= 75 * this.mHeight + 10 && this.mHeight >= 2
+                && this.checkPiece(STRUCTURE_PIECE_TOP_HINT, 7, this.mHeight * 5, 0)
                 && this.mTopLayerFound
                 && this.mMaintenanceHatches.size() == 1;
     }


### PR DESCRIPTION
Problem: In game the incompleted mega distill tower is detected as completed.

![issue](https://github.com/GTNewHorizons/bartworks/assets/72639018/3662d04a-594d-4343-8cca-5f195b5ae09c)

Possible reason: structure check forgot to ensure that the top layer is completed.

PS: I do not have a Java debug environment. :<